### PR TITLE
Fix error when using -unittest in another project with vecs as a dependency

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -7,15 +7,16 @@
 	"license": "MIT",
 	"targetType": "library",
 	"configurations": [
-        {
-            "name": "default"
-        },
-        {
-            "name": "unittest",
-            "targetType": "autodetect",
-            "dependencies": {
-                "aurorafw:unit": "0.0.1-alpha.4"
-			}
-        }
-    ]
+		{
+			"name": "default"
+		},
+		{
+			"name": "unittest",
+			"targetType": "autodetect",
+			"dependencies": {
+				"aurorafw:unit": "0.0.1-alpha.4"
+			},
+			"versions": ["vecs_unittest"]
+		}
+	]
 }

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -12,7 +12,7 @@ import std.range : iota;
 import std.traits : isInstanceOf, TemplateArgsOf;
 import std.typecons : Nullable, Tuple, tuple;
 
-version(unittest)
+version(vecs_unittest)
 {
 	import aurorafw.unit.assertion;
 	import std.exception : assertThrown;

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -2,7 +2,7 @@ module vecs.entitybuilder;
 
 import vecs.entity;
 
-version(unittest) import aurorafw.unit.assertion;
+version(vecs_unittest) import aurorafw.unit.assertion;
 
 
 /**

--- a/source/vecs/query.d
+++ b/source/vecs/query.d
@@ -11,7 +11,7 @@ import std.range : iota;
 import std.traits : isInstanceOf, staticMap, TemplateArgsOf;
 import std.typecons : Tuple, tuple;
 
-version(unittest) import aurorafw.unit.assertion;
+version(vecs_unittest) import aurorafw.unit.assertion;
 
 struct Query(Output)
 {

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -6,7 +6,7 @@ import std.meta : allSatisfy;
 import std.traits : isSomeChar, isCopyable, isDelegate, isFunctionPointer, isInstanceOf, isMutable, isSomeFunction, Fields;
 import std.typecons : Tuple;
 
-version(unittest)
+version(vecs_unittest)
 {
 	import aurorafw.unit.assertion;
 	import std.exception : assertThrown;
@@ -400,7 +400,7 @@ private:
 	Component[] _components;
 }
 
-version(unittest)
+version(vecs_unittest)
 {
 	struct Foo { int x, y; }
 	struct Bar { string str; }


### PR DESCRIPTION
Running a project with -unittest was causing a dependency error because vecs was using `aurorafw:unit` as dependency and importing it inside `version(unittest)`.