### PR TITLE
Add queryOne method

### DIFF
--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -549,6 +549,14 @@ public:
 
 
 	///
+	auto queryOne(Output)() { return query!Output.front; }
+
+
+	///
+	auto queryOne(Output, Filter)() { return query!(Output, Filter).front; }
+
+
+	///
 	@safe pure @property
 	Entity[] entities()
 	{

--- a/source/vecs/query.d
+++ b/source/vecs/query.d
@@ -62,6 +62,7 @@ unittest
 
 	assertRangeEquals([Entity(0),Entity(1),Entity(4),Entity(8)], em.query!Entity);
 	assertRangeEquals(em.query!(Tuple!Entity), em.query!Entity);
+	assertEquals(Entity(0), em.queryOne!Entity);
 }
 
 @safe pure
@@ -86,6 +87,7 @@ unittest
 	assertEquals(5, em.query!int.range.entities.length);
 	assertRangeEquals([4,0,0,0,0], em.query!int.map!"*a");
 	assertRangeEquals(em.query!(Tuple!int), em.query!int);
+	assertEquals(4, *em.queryOne!int);
 }
 
 @safe pure
@@ -117,6 +119,10 @@ unittest
 
 	assertEquals(5, em.query!(Tuple!(int, Bar)).range.entities.length);
 	assertRangeEquals(range, em.query!(Tuple!(int, Bar)).map!"tuple(*a[0], *a[1])");
+
+	int* i; Bar* bar;
+	AliasSeq!(i, bar) = em.queryOne!(Tuple!(int, Bar));
+	assertEquals(tuple(4, Bar.init), tuple(*i, *bar));
 
 	assertFalse(__traits(compiles, em.query!(Tuple!(Entity,Entity))));
 	assertFalse(__traits(compiles, em.query!(Tuple!(int,Entity))));
@@ -192,10 +198,12 @@ unittest
 	auto range = [Entity(0),Entity(6),Entity(7),Entity(8),Entity(9)];
 	assertEquals(5, em.query!(Entity, With!int).range.entities.length);
 	assertRangeEquals(range, em.query!(Entity, With!int)());
+	assertEquals(Entity(0), em.queryOne!(Entity, With!int)());
 
 	range = [Entity(0),Entity(8),Entity(9)];
 	assertEquals(5, em.query!(Entity, With!(int,Foo,Bar)).range.entities.length);
 	assertRangeEquals(range, em.query!(Entity, With!(int,Foo,Bar)));
+	assertEquals(Entity(0), em.queryOne!(Entity, With!(int,Foo,Bar))());
 }
 
 @safe pure

--- a/source/vecs/queryworld.d
+++ b/source/vecs/queryworld.d
@@ -113,10 +113,10 @@ package struct QueryWorld(OutputTuple)
 	@property
 	auto front()
 	{
-		auto e = entities[0];
-		enum components = format!q{%(sinfos[%s].get!(Components[%s]).get(entities[0])%|,%)}(Components.length.iota);
+		immutable e = entities[0];
+		enum components = format!q{%(sinfos[%s].get!(Components[%s]).get(e)%|,%)}(Components.length.iota);
 		static if (is(Out[0] == Entity))
-			return mixin(format!q{tuple(entities[0], %s)}(components));
+			return mixin(format!q{tuple(e, %s)}(components));
 		else
 			return mixin(format!q{tuple(%s)}(components));
 	}


### PR DESCRIPTION
The queryOne method is useful for queries when the user knows or wants one element as the output. Instead of a range as the output, the user receives the element itself. For example:
```d
auto em = new EntityManager();
em.gen(3);
assert(3 == *em.queryOne!int);
```