### PR TITLE
Add signals

### DIFF
--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -55,7 +55,7 @@ private:
 }
 
 
-@safe pure
+@system
 @("entitybuilder: entityBuilder")
 unittest
 {

--- a/source/vecs/query.d
+++ b/source/vecs/query.d
@@ -43,7 +43,7 @@ private:
 	QueryWorld!Output range;
 }
 
-@safe pure
+@system
 @("query: Entity")
 unittest
 {
@@ -65,7 +65,7 @@ unittest
 	assertEquals(Entity(0), em.queryOne!Entity);
 }
 
-@safe pure
+@system
 @("query: Component")
 unittest
 {
@@ -90,7 +90,7 @@ unittest
 	assertEquals(4, *em.queryOne!int);
 }
 
-@safe pure
+@system
 @("query: OutputTuple")
 unittest
 {
@@ -178,7 +178,7 @@ private:
 	QueryFilter!Filter filter;
 }
 
-@safe pure
+@system
 @("query: Entity + Filter")
 unittest
 {
@@ -206,7 +206,7 @@ unittest
 	assertEquals(Entity(0), em.queryOne!(Entity, With!(int,Foo,Bar))());
 }
 
-@safe pure
+@system
 @("query: Component + Filter")
 unittest
 {
@@ -246,7 +246,7 @@ unittest
 	assertRangeEquals(range, em.query!(Tuple!(Entity, int), With!(Foo,Bar)).map!"tuple(a[0],*a[1])");
 }
 
-@safe pure
+@system
 @("query: OutputTuple + Filter")
 unittest
 {
@@ -274,7 +274,7 @@ unittest
 	assertRangeEquals(range, em.query!(int, With!(Foo,Bar)).map!"*a");
 }
 
-@safe pure
+@system
 @("query: OutputTuple + FilterTuple")
 unittest
 {

--- a/source/vecs/signal.d
+++ b/source/vecs/signal.d
@@ -1,0 +1,84 @@
+module vecs.signal;
+
+version(vecs_unittest) import aurorafw.unit.assertion;
+
+struct Signal(T ...)
+{
+	alias SlotType = void delegate(T);
+	alias SlotTypeRef = void delegate(ref T);
+
+	@safe pure nothrow
+	void connect(SlotType slot)
+	{
+		slots ~= slot;
+	}
+
+	@safe pure nothrow
+	void disconnect(SlotType slot)
+	{
+		import std.algorithm : countUntil;
+		auto index = slots.countUntil(slot);
+		if (index != -1)
+		{
+			slots = slots[0 .. index] ~ slots[index+1 .. $];
+		}
+	}
+
+	@system
+	void emit(T args)
+	{
+		foreach (ref slot; slots) {
+			slot(args);
+		}
+	}
+
+	SlotType[] slots;
+}
+
+@system
+@("signal: empty")
+unittest
+{
+	Signal!() sig; // empty signal
+	size_t num;
+	auto fun = () { num++; };
+
+	sig.connect(fun);
+	sig.emit();
+	assertEquals(1, num);
+
+	sig.disconnect(fun);
+	sig.emit();
+	assertEquals(1, num);
+}
+
+@system
+@("signal: different instances having the same Signal type")
+unittest
+{
+	Signal!(int) sigA;
+	Signal!(int) sigB;
+	size_t num;
+
+	sigA.connect((int x) { num = x; });
+	sigB.connect((int x) { num += x; });
+
+	sigA.emit(4);
+	sigB.emit(16);
+	assertEquals(20, num);
+}
+
+@system
+@("signal: using a function")
+unittest
+{
+	import std.functional : toDelegate;
+	Signal!(size_t*) sig;
+	size_t num;
+
+	auto fun = function(size_t* n) { (*n)++; };
+	sig.connect(toDelegate(fun));
+
+	sig.emit(&num);
+	assertEquals(1, num);
+}


### PR DESCRIPTION
Changes:
 * Add Signal struct
 * Add onSet and onRemove signals
 * Refactor multiple methods, depending on Signal, to @system only
 * Signals:
   * onSet - emits **after** setting a component
   * onRemove - emits **before** removing a component

Usage:
```d
auto fun = () { writeln("look mah, another signal!"); }
auto em = new EntityManager();

// after set on int, this will be emitted
// multiple callbacks can be bound

em.onSet!int().connect = () { writeln("look mah, a signal emission!"); }
em.onSet!int().connect = fun;

auto e = em.gen!Foo; // emits onSet

// output:
// look mah, a signal emission!
// look mah, another signal!

// signals can be disconnected
// disconnected signals are no longer called

em.onSet!int().disconnect(fun);
em.set(e, Foo(2,3)); // emits onSet

// output:
// look mah, a signal emission!
```

The objective of this feature isn't only for users to have access to internal events but to be able to define their own signals with ease! Instead of having the generic systems with code logic that should not be in them, they can just create signals, connect some specific systems and emit the same. Let's take as an example a collision. Should the logic be implemented in the movement system, or should we have a generic collision system that loops every position to find the colliding ones, or should we just execute the code when entities collide? The latter is the best solution and can be easily accomplished using signals. Just create an onCollision signal, bind a system to it, and when a collision occurs just emit it!

Using Signal is as simple as:
```d
// create a signal which receives void delegate(int) delegates
Signal!int sig;

// delegate to connect
auto fun = delegate(int) {};

// to connect a callback:
sig.connect(fun);

// to emit a signal:
sig.emit(3);

// to disconnect a callback:
sig.disconnect(fun);

// every signal returns void
```