### PR TITLE
Query and methods bug fixes and documentation refactoring

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*]
+insert_final_newline = true
+indent_size = 4
+indent_style = tab
+tab_width = 4
+trim_trailing_whitespace = true

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An Entity Component System library written in D.
 ## Brief
 An entity component system is a pattern used mostly in gamedev. The objective is
 to classify everything in a game as an `Entity`. `Components` are just data
-structures used to give so sort of meaning to the generated entities. Some
+structures used to give some sort of meaning to the generated entities. Some
 common examples are: `Position`, `Velocity`, `Sprite`. All these components can
 be associated to an entity. An entity can be rendered if has `Position` and
 `Sprite`, etc. Components can be almost anything! A `System` gives functionality
@@ -65,6 +65,17 @@ void systemC(Query!(Tuple!(Position,Velocity), Tuple!(With!Grounder, Without!Cra
 void main()
 {
 	auto em = new EntityManager();
+
+	// listen to signals
+	em.onSet!Grounder((Entity,Grounder*) {
+		import std.stdio : writeln;
+		"A Grounder has born".writeln;
+	});
+
+	em.onRemove!Grounder((Entity,Grounder*) {
+		import std.stdio : writeln;
+		"A Grounder has died".writeln;
+	})
 
 	em.entityBuilder()
 		.gen!Position

--- a/examples/signals/basic/dub.json
+++ b/examples/signals/basic/dub.json
@@ -1,0 +1,10 @@
+{
+	"name": "basic",
+	"targetType": "executable",
+	"targetPath": "../../.out/bin",
+	"sourcePaths": ["source"],
+	"importPaths": ["source"],
+	"dependencies": {
+		"valhalla_ecs": {"path": "../../../"}
+	}
+}

--- a/examples/signals/basic/dub.selections.json
+++ b/examples/signals/basic/dub.selections.json
@@ -1,0 +1,7 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"aurorafw": "0.0.1-alpha.4",
+		"valhalla_ecs": {"path":"../../../"}
+	}
+}

--- a/examples/signals/basic/source/app.d
+++ b/examples/signals/basic/source/app.d
@@ -1,0 +1,105 @@
+module app;
+
+import vecs;
+
+import std.stdio;
+
+  // ====================
+ // Simple combat system
+// ====================
+
+void combatSystem(Body* enemy, Query!(Body, Without!Enemy) query)
+{
+	foreach (b; query)
+	{
+		// enemy gets hit
+		onHit.emit(b, enemy);
+		if (enemy.hp <= 0) break;
+
+		// enemy hits back
+		onHit.emit(enemy, b);
+		if (b.hp <= 0) break;
+	}
+}
+
+
+  // =================
+ // Game State system
+// =================
+
+void gameSystem(Query!Body query, State* state)
+{
+	import std.algorithm : filter, each;
+	import std.typecons : No;
+
+	query.filter!"a.hp <= 0".each!((q) {
+		*state = State.over;
+		return No.each;
+	});
+}
+
+
+  // ==========================
+ // Listens to onHit emissions
+// ==========================
+
+void hitListener(Body* hit, Body* damaged)
+{
+	import std.format : format;
+
+	damaged.hp -= hit.damage;
+	writefln!"%s was hitted by %s and suffered %s damage! HP left: %s"(damaged.name, hit.name, hit.damage, damaged.hp);
+}
+
+
+  // ======================
+ // Components and Signals
+// ======================
+
+struct Body { int hp; int damage; string name; }
+struct Enemy {}
+enum State { over, running }
+
+Signal!(Body*,Body*) onHit;
+
+
+void main()
+{
+	auto em = new EntityManager();
+
+	  // ============
+	 // Bind signals
+	// ============
+
+	import std.functional : toDelegate;
+	onHit.connect(toDelegate(&hitListener));
+
+	// on Body set
+	em.onSet!Body().connect((Entity,Body* b) {
+		writefln!"Entity %s created with %s HP and %s damage."(b.name, b.hp, b.damage);
+	});
+
+
+	  // ===============
+	 // Create entities
+	// ===============
+
+	em.entityBuilder()
+		.gen(Body(10, 3, "Foo"))
+		.gen(Body(10, 3, "Bar"))
+		.gen(Body(13, 1, "Enemy"), Enemy())
+		.gen(State.running);
+
+
+	  // =========
+	 // Main loop
+	// =========
+
+	while (*em.queryOne!State() == State.running)
+	{
+		combatSystem(em.queryOne!(Body, With!Enemy), em.query!(Body, Without!Enemy));
+		gameSystem(em.query!Body, em.queryOne!State);
+	}
+
+	"Over!".writeln;
+}

--- a/examples/signals/dub.json
+++ b/examples/signals/dub.json
@@ -1,11 +1,10 @@
 {
-    "name": "examples",
+	"name": "signals",
     "targetType": "none",
     "dependencies": {
-        ":benchmarks": "*"
+        ":query": "*"
     },
     "subPackages": [
-        "benchamrks",
-		"signals"
+        "basic"
     ]
 }

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -101,18 +101,11 @@ public:
 
 
 	@safe pure nothrow @nogc
-	auto incrementBatch()
-	{
-		_batch = _batch >= maxbatch ? 0 : _batch + 1;
-
-		return this;
-	}
-
-	@safe pure nothrow @nogc
 	size_t signature() const
 	{
 		return (_id | (_batch << idshift));
 	}
+
 
 	static if (typeof(int.sizeof).sizeof == 4)
 	{
@@ -135,6 +128,14 @@ public:
 	alias signature this;
 
 private:
+	@safe pure nothrow @nogc
+	auto incrementBatch()
+	{
+		_batch = _batch >= maxbatch ? 0 : _batch + 1;
+
+		return this;
+	}
+
 	size_t _id;
 	size_t _batch;
 }

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -427,9 +427,8 @@ public:
 	 *     Component = a valid component to remove.
 	 */
 	void removeIfHas(Component)(in Entity e)
-		in (has(e))
 	{
-		_assureStorage!Component().removeIfHas(e);
+		if (has(e)) _assureStorage!Component().removeIfHas(e);
 	}
 
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -62,13 +62,15 @@ class MaximumEntitiesReachedException : Exception { mixin basicExceptionCtors; }
 struct Entity
 {
 public:
-	@safe pure this(in size_t id)
+	@safe pure nothrow @nogc
+	this(in size_t id)
 		in (id <= maxid)
 	{
 		_id = id;
 	}
 
-	@safe pure this(in size_t id, in size_t batch)
+	@safe pure nothrow @nogc
+	this(in size_t id, in size_t batch)
 		in (id <= maxid)
 		in (batch <= maxbatch)
 	{
@@ -77,22 +79,28 @@ public:
 	}
 
 
-	@safe pure
+	@safe pure nothrow @nogc
 	bool opEquals(in Entity other) const
 	{
 		return other.signature == signature;
 	}
 
 
-	@property @safe pure
-	size_t id() const { return _id; }
+	@safe pure nothrow @nogc @property
+	size_t id() const
+	{
+		return _id;
+	}
 
 
-	@property @safe pure
-	size_t batch() const { return _batch; }
+	@safe pure nothrow @nogc @property
+	size_t batch() const
+	{
+		return _batch;
+	}
 
 
-	@safe pure
+	@safe pure nothrow @nogc
 	auto incrementBatch()
 	{
 		_batch = _batch >= maxbatch ? 0 : _batch + 1;
@@ -100,7 +108,7 @@ public:
 		return this;
 	}
 
-	@safe pure
+	@safe pure nothrow @nogc
 	size_t signature() const
 	{
 		return (_id | (_batch << idshift));
@@ -171,9 +179,11 @@ unittest
 class EntityManager
 {
 public:
-	enum Entity entityNull = Entity(Entity.maxid);
-
-	@safe pure this() { queue = entityNull; }
+	@safe pure nothrow @nogc
+	this()
+	{
+		queue = entityNull;
+	}
 
 
 	/**
@@ -309,7 +319,6 @@ public:
 	 *
 	 * Returns: Signal!(Entity,Component*)
 	 */
-	@property
 	ref auto onSet(Component)()
 	{
 		return _assureStorage!Component.onSet;
@@ -326,7 +335,6 @@ public:
 	 *
 	 * Returns: Signal!(Entity,Component*)
 	 */
-	@property
 	ref auto onRemove(Component)()
 	{
 		return _assureStorage!Component.onRemove;
@@ -522,7 +530,7 @@ public:
 	 *
 	 * Returns: an EntityBuilder.
 	 */
-	@safe pure
+	@safe pure nothrow @nogc
 	auto entityBuilder()
 	{
 		import vecs.entitybuilder : EntityBuilder;
@@ -531,7 +539,7 @@ public:
 
 
 	///
-	@safe pure
+	@safe pure nothrow @nogc
 	bool has(in Entity e) const
 		in (e.id < Entity.maxid)
 	{
@@ -630,8 +638,8 @@ public:
 
 
 	///
-	@safe pure @property
-	Entity[] entities()
+	@safe pure nothrow @property
+	Entity[] entities() const
 	{
 		import std.array : appender;
 		auto ret = appender!(Entity[]);
@@ -675,7 +683,7 @@ private:
 	 *
 	 * Returns: an Entity previously fabricated with a new batch.
 	 */
-	@safe pure
+	@safe pure nothrow @nogc
 	Entity recycle()
 		in (!queue.isNull)
 	{
@@ -733,7 +741,7 @@ private:
 
 
 	///
-	StorageInfo _assureStorageInfo(Component)()
+	auto ref StorageInfo _assureStorageInfo(Component)()
 		if (isComponent!Component)
 	{
 		immutable index = _assure!Component();
@@ -865,6 +873,9 @@ private:
 	Entity[] _entities;
 	Nullable!(Entity, entityNull) queue;
 	StorageInfo[] storageInfoMap;
+
+public:
+	enum Entity entityNull = Entity(Entity.maxid);
 }
 
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -945,7 +945,7 @@ private:
 		if (isComponent!Component)
 	{
 		auto storage = _assureStorage!Component();
-		auto entities = _queryEntities!(Component, Extra);
+		auto entities = _queryEntities!(Component);
 		return QueryWorld!Component(entities.idup, storage.components());
 	}
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -125,8 +125,6 @@ public:
 	enum size_t idmask = maxid; // first 20 bits (sizeof==4), 32 bits (sizeof==8)
 	enum size_t batchmask = maxbatch << idshift; // last 12 bits (sizeof==4), 32 bits (sizeof==8)
 
-	alias signature this;
-
 private:
 	@safe pure nothrow @nogc
 	auto incrementBatch()

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -6,9 +6,7 @@ version(vecs_unittest) import aurorafw.unit.assertion;
 
 
 /**
- * Helper struct to perform multiple actions sequences.
- *
- * Params: em = an entity manager to update.
+ * Helper struct to perform multiple action sequences.
  */
 struct EntityBuilder
 {
@@ -20,6 +18,7 @@ public:
 	}
 
 
+	/// Uses EntityManager's gen method
 	@safe pure
 	auto gen()
 	{
@@ -28,6 +27,7 @@ public:
 	}
 
 
+	/// Ditto
 	auto gen(ComponentRange ...)()
 	{
 		entities ~= em.gen!(ComponentRange)();
@@ -35,6 +35,7 @@ public:
 	}
 
 
+	/// Ditto
 	auto gen(ComponentRange ...)(ComponentRange components)
 	{
 		entities ~= em.gen(components);
@@ -42,8 +43,13 @@ public:
 	}
 
 
+	/**
+	 * Gets all entities generated with an instance of EntityBuilder.
+	 *
+	 * Returns: `Entity[]` with the generated entities.
+	 */
 	@safe pure nothrow @nogc
-	auto get()
+	Entity[] get()
 	{
 		return entities;
 	}

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -13,7 +13,7 @@ version(vecs_unittest) import aurorafw.unit.assertion;
 struct EntityBuilder
 {
 public:
-	@safe pure
+	@safe pure nothrow @nogc
 	this(EntityManager em)
 	{
 		this.em = em;
@@ -42,7 +42,7 @@ public:
 	}
 
 
-	@safe pure
+	@safe pure nothrow @nogc
 	auto get()
 	{
 		return entities;

--- a/source/vecs/package.d
+++ b/source/vecs/package.d
@@ -6,4 +6,5 @@ public:
 	import vecs.query;
 	import vecs.queryfilter;
 	import vecs.queryworld;
+	import vecs.signal;
 	import vecs.storage;

--- a/source/vecs/query.d
+++ b/source/vecs/query.d
@@ -16,24 +16,26 @@ version(vecs_unittest) import aurorafw.unit.assertion;
 struct Query(Output)
 {
 package:
+	@safe pure nothrow @nogc
 	this(QueryWorld!Output range)
 	{
 		this.range = range;
 	}
 
 public:
+	@safe pure nothrow @nogc
 	void popFront()
 	{
 		range.popFront();
 	}
 
-	@property
+	@safe pure nothrow @nogc @property
 	bool empty()
 	{
 		return range.empty;
 	}
 
-	@property
+	@safe pure nothrow @nogc @property
 	auto front()
 	{
 		return range.front;
@@ -135,6 +137,7 @@ unittest
 struct Query(Output, Filter)
 {
 package:
+	@safe pure nothrow @nogc
 	this(QueryWorld!Output range, QueryFilter!Filter filter)
 	{
 		this.range = range;
@@ -143,6 +146,7 @@ package:
 	}
 
 public:
+	@safe pure nothrow @nogc
 	void popFront()
 	{
 		do {
@@ -150,25 +154,27 @@ public:
 		} while (!empty && !_validate());
 	}
 
-	@property
+	@safe pure nothrow @nogc @property
 	bool empty()
 	{
 		return range.empty;
 	}
 
-	@property
+	@safe pure nothrow @nogc @property
 	auto front()
 	{
 		return range.front;
 	}
 
 private:
+	@safe pure nothrow @nogc
 	void _prime()
 	{
 		while (!empty && !_validate())
 			popFront();
 	}
 
+	@safe pure nothrow @nogc
 	bool _validate()
 	{
 		return filter.validate(range.entities[0]);

--- a/source/vecs/queryfilter.d
+++ b/source/vecs/queryfilter.d
@@ -20,11 +20,13 @@ struct With(T ...)
 	if (areFilterArgs!T)
 {
 package:
+	@safe pure nothrow @nogc
 	this(StorageInfo[] sinfos)
 	{
 		this.sinfos = sinfos;
 	}
 
+	@safe pure nothrow @nogc
 	bool opCall(in Entity e)
 	{
 		foreach (sinfo; sinfos)
@@ -45,11 +47,13 @@ struct Without(T ...)
 	if (areFilterArgs!T)
 {
 package:
+	@safe pure nothrow @nogc
 	this(StorageInfo[] sinfos)
 	{
 		this.sinfos = sinfos;
 	}
 
+	@safe pure nothrow @nogc
 	bool opCall(in Entity e)
 	{
 		foreach (sinfo; sinfos)
@@ -67,11 +71,13 @@ package:
 package struct QueryFilter(Filter)
 	if (isFilter!Filter)
 {
+	@safe pure nothrow @nogc
 	this(Filter filter)
 	{
 		this.filter = filter;
 	}
 
+	@safe pure nothrow @nogc
 	bool validate(in Entity e) {
 		return filter(e);
 	}
@@ -84,11 +90,13 @@ package struct QueryFilter(Filter)
 package struct QueryFilter(FilterTuple)
 	if (isInstanceOf!(Tuple, FilterTuple) && allSatisfy!(isFilter, TemplateArgsOf!(FilterTuple)))
 {
+	@safe pure nothrow @nogc
 	this(FilterTuple filters)
 	{
 		this.filters = filters;
 	}
 
+	@safe pure nothrow @nogc
 	bool validate(in Entity e) {
 		foreach (filter; filters)
 			if (!filter(e))

--- a/source/vecs/queryworld.d
+++ b/source/vecs/queryworld.d
@@ -47,6 +47,7 @@ package struct QueryWorld(Output)
 {
 	@safe pure nothrow @nogc
 	this(immutable Entity[] entities, Output[] components)
+		in (entities.length == components.length)
 	{
 		this.entities = entities;
 		this.components = components;

--- a/source/vecs/queryworld.d
+++ b/source/vecs/queryworld.d
@@ -8,26 +8,28 @@ import std.range : iota;
 import std.traits : isInstanceOf, TemplateArgsOf;
 import std.typecons : Tuple, tuple;
 
-@safe
+
 package struct QueryWorld(Output : Entity)
 {
+	@safe pure nothrow @nogc
 	this(immutable Entity[] entities)
 	{
 		this.entities = entities;
 	}
 
+	@safe pure nothrow @nogc
 	void popFront()
 	{
 		entities = entities[1..$];
 	}
 
-	@property
+	@safe pure nothrow @nogc @property
 	bool empty()
 	{
 		return entities.length == 0;
 	}
 
-	@property
+	@safe pure nothrow @nogc @property
 	Entity front()
 	{
 		return entities[0];
@@ -36,31 +38,34 @@ package struct QueryWorld(Output : Entity)
 	immutable(Entity)[] entities;
 }
 
+
 alias QueryWorld(T : Tuple!Entity) = QueryWorld!Entity;
 
 
 package struct QueryWorld(Output)
 	if (isComponent!Output)
 {
+	@safe pure nothrow @nogc
 	this(immutable Entity[] entities, Output[] components)
 	{
 		this.entities = entities;
 		this.components = components;
 	}
 
+	@safe pure nothrow @nogc
 	void popFront()
 	{
 		entities = entities[1..$];
 		components = components[1..$];
 	}
 
-	@property
+	@safe pure nothrow @nogc @property
 	bool empty()
 	{
 		return entities.length == 0;
 	}
 
-	@property
+	@safe pure nothrow @nogc @property
 	Output* front()
 	{
 		return &components[0];
@@ -71,10 +76,10 @@ package struct QueryWorld(Output)
 }
 
 
-@safe
 package struct QueryWorld(OutputTuple)
 	if (isInstanceOf!(Tuple, OutputTuple))
 {
+	@safe pure nothrow @nogc
 	this(immutable Entity[] entities, StorageInfo[] sinfos)
 	{
 		this.entities = entities;
@@ -82,12 +87,14 @@ package struct QueryWorld(OutputTuple)
 		_prime();
 	}
 
+	@safe pure nothrow @nogc
 	void _prime()
 	{
 		while (!empty && !_validate())
 			popFront();
 	}
 
+	@safe pure nothrow @nogc
 	bool _validate()
 	{
 		foreach (sinfo; sinfos)
@@ -97,6 +104,7 @@ package struct QueryWorld(OutputTuple)
 		return true;
 	}
 
+	@safe pure nothrow @nogc
 	void popFront()
 	{
 		do {
@@ -104,13 +112,13 @@ package struct QueryWorld(OutputTuple)
 		} while (!empty && !_validate());
 	}
 
-	@property
+	@safe pure nothrow @nogc @property
 	bool empty()
 	{
 		return entities.length == 0;
 	}
 
-	@property
+	@safe pure nothrow @nogc @property
 	auto front()
 	{
 		immutable e = entities[0];

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -1,6 +1,7 @@
 module vecs.storage;
 
 import vecs.entity : Entity;
+import vecs.signal;
 
 import std.meta : allSatisfy;
 import std.traits : isSomeChar, isCopyable, isDelegate, isFunctionPointer, isInstanceOf, isMutable, isSomeFunction, Fields;
@@ -177,14 +178,16 @@ public:
 		return (() @trusted pure nothrow @nogc => cast(Storage!Component) storage)(); // safe cast
 	}
 
-	Entity[] delegate() @safe pure nothrow @property @nogc entities;
 	bool delegate(in Entity e) @safe pure nothrow @nogc const has;
 	void delegate(in Entity e) @system remove;
 	void delegate() @trusted pure removeAll;
 	void delegate(in Entity e) @system removeIfHas;
 	size_t delegate() @safe pure nothrow @nogc @property const size;
 
+
 package:
+	Entity[] delegate() @safe pure nothrow @property @nogc entities;
+
 	TypeInfo cid;
 	void* storage;
 }
@@ -402,6 +405,7 @@ package class Storage(Component)
 	}
 
 
+package:
 	/**
 	 * Gets the entities stored.
 	 *
@@ -425,10 +429,6 @@ package class Storage(Component)
 		return _components;
 	}
 
-
-	import vecs.signal;
-	Signal!(Entity,Component*) onSet;
-	Signal!(Entity,Component*) onRemove;
 
 private:
 	/**
@@ -462,6 +462,10 @@ private:
 	size_t[] _sparsedEntities;
 	Entity[] _packedEntities;
 	Component[] _components;
+
+public:
+	Signal!(Entity,Component*) onSet;
+	Signal!(Entity,Component*) onRemove;
 }
 
 version(vecs_unittest)

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -161,7 +161,7 @@ public:
 		auto storage = new Storage!Component();
 		this.cid = TypeInfoComponent!Component;
 
-		(() @trusted => this.storage = cast(void*) storage)();
+		(() @trusted pure nothrow @nogc => this.storage = cast(void*) storage)();
 		this.entities = &storage.entities;
 		this.has = &storage.has;
 		this.remove = &storage.remove;
@@ -174,15 +174,15 @@ public:
 	Storage!Component get(Component)()
 		in (cid is TypeInfoComponent!Component)
 	{
-		return (() @trusted => cast(Storage!Component) storage)(); // safe cast
+		return (() @trusted pure nothrow @nogc => cast(Storage!Component) storage)(); // safe cast
 	}
 
-	Entity[] delegate() @safe pure @property entities;
-	bool delegate(in Entity e) @safe pure has;
+	Entity[] delegate() @safe pure nothrow @property @nogc entities;
+	bool delegate(in Entity e) @safe pure nothrow @nogc const has;
 	void delegate(in Entity e) @system remove;
 	void delegate() @trusted pure removeAll;
 	void delegate(in Entity e) @system removeIfHas;
-	size_t delegate() @safe pure size;
+	size_t delegate() @safe pure nothrow @nogc @property const size;
 
 package:
 	TypeInfo cid;
@@ -330,7 +330,7 @@ package class Storage(Component)
 	 *
 	 * Returns: a pointer to the Component.
 	 */
-	@safe pure
+	@safe pure nothrow @nogc
 	Component* get(in Entity e)
 		in (has(e))
 	{
@@ -367,7 +367,7 @@ package class Storage(Component)
 
 
 	///
-	@safe pure
+	@safe pure nothrow @nogc @property
 	size_t size() const
 	{
 		return _components.length;
@@ -375,7 +375,7 @@ package class Storage(Component)
 
 
 	///
-	@safe pure
+	@safe pure nothrow @nogc
 	bool has(in Entity e) const
 	{
 		return e.id < _sparsedEntities.length
@@ -385,14 +385,14 @@ package class Storage(Component)
 
 
 	///
-	@safe pure @property
+	@safe pure nothrow @nogc @property
 	Entity[] entities()
 	{
 		return _packedEntities;
 	}
 
 
-	@safe pure @property
+	@safe pure nothrow @nogc @property
 	Component[] components()
 	{
 		return _components;


### PR DESCRIPTION
Fixed:
 * Query when built with 1 component and a filter was storing the wrong components, leading to a wrong output.
 * Multiple functions were lacking attributes.
 * Remove alias this from Entity, its intended behavior being overshadowed by opEquals making it unused.
 * Fixed removeIfHas method in EntityManager not safely evaluating an entity.
 * Refactor entities and components methods in Storage to package visibility.
 * Added signal module to package.d