### PR TITLE
Add resources

### DIFF
--- a/examples/signals/basic/source/app.d
+++ b/examples/signals/basic/source/app.d
@@ -27,13 +27,13 @@ void combatSystem(Body* enemy, Query!(Body, Without!Enemy) query)
  // Game State system
 // =================
 
-void gameSystem(Query!Body query, State* state)
+void gameSystem(Query!Body query, ref State state)
 {
 	import std.algorithm : filter, each;
 	import std.typecons : No;
 
 	query.filter!"a.hp <= 0".each!((q) {
-		*state = State.over;
+		state = State.over;
 		return No.each;
 	});
 }
@@ -80,6 +80,13 @@ void main()
 	});
 
 
+	  // ================
+	 // Create resources
+	// ================
+
+	em.addResource(State.running);
+
+
 	  // ===============
 	 // Create entities
 	// ===============
@@ -87,18 +94,18 @@ void main()
 	em.entityBuilder()
 		.gen(Body(10, 3, "Foo"))
 		.gen(Body(10, 3, "Bar"))
-		.gen(Body(13, 1, "Enemy"), Enemy())
-		.gen(State.running);
+		.gen(Body(13, 1, "Enemy"), Enemy());
+
 
 
 	  // =========
 	 // Main loop
 	// =========
 
-	while (*em.queryOne!State() == State.running)
+	while (em.resource!State() == State.running)
 	{
 		combatSystem(em.queryOne!(Body, With!Enemy), em.query!(Body, Without!Enemy));
-		gameSystem(em.query!Body, em.queryOne!State);
+		gameSystem(em.query!Body, em.resource!State);
 	}
 
 	"Over!".writeln;

--- a/source/vecs/package.d
+++ b/source/vecs/package.d
@@ -8,3 +8,4 @@ public:
 	import vecs.queryworld;
 	import vecs.signal;
 	import vecs.storage;
+	import vecs.resource;

--- a/source/vecs/resource.d
+++ b/source/vecs/resource.d
@@ -1,0 +1,101 @@
+module vecs.resource;
+
+version(vecs_unittest)
+{
+	import aurorafw.unit.assertion;
+	import vecs.entity;
+}
+
+
+///
+@safe nothrow @nogc
+private static size_t nextId()
+{
+	static size_t value;
+	return value++;
+}
+
+
+///
+template ResourceId(Res)
+{
+	size_t ResourceId()
+	{
+		auto ResourceIdImpl = ()
+		{
+			static bool initialized;
+			static size_t id;
+
+			if (!initialized)
+			{
+				id = nextId();
+				initialized = true;
+			}
+
+			return id;
+		};
+
+		import vecs.storage : assumePure;
+		return (() @trusted pure nothrow @nogc => assumePure(ResourceIdImpl)())();
+	}
+}
+
+
+enum isResource(R) = is(R == class)
+	|| is(R == struct)
+	|| is(R == enum);
+
+
+/**
+ * A wrapper to store any data type.
+ */
+package struct Resource
+{
+	void[] data;
+}
+
+
+version(vecs_unittest)
+{
+	struct State { string name; }
+	class CState
+	{
+		@safe pure nothrow @nogc
+		this(float a, float b) { fa = a; fb = b; }
+
+		@safe pure nothrow @nogc
+		override bool opEquals(const Object other) const
+		{
+			CState rhs = (() @trusted pure nothrow @nogc => cast(CState) other)();
+			if (rhs is null) return false;
+			return fa == rhs.fa && fb == rhs.fb;
+		}
+
+		float fa,fb;
+	}
+	enum EState { a, b }
+}
+
+@("resource: Resource")
+@system
+unittest
+{
+	auto em = new EntityManager();
+
+	em.addResource!State;
+	assertEquals("", em.resource!State.name);
+
+	em.addResource!CState;
+	assertNull(em.resource!CState);
+
+	// replace old CState resource
+	em.addResource(new CState(2f, 5f));
+	assertEquals(new CState(2f, 5f), em.resource!CState);
+
+	em.addResource(EState.b);
+	assertEquals(EState.b, em.resource!EState);
+
+	assertFalse(__traits(compiles, em.addResource!(int)()));
+	assertFalse(__traits(compiles, em.addResource!(int[])()));
+	assertFalse(__traits(compiles, em.addResource!(State*)()));
+}


### PR DESCRIPTION
Resources are similar to components but linked to the EntityManager instead of an entity. For example, Events, States, Properties are all data that could be set as a resource. Resources store a unique instance of a type, it's impossible to store more than one instance of a type. Knowing this, resources are similar to global instances within EntityManager.

```d
import vecs;

enum GameState { playing, gameOver }
struct GameProps
{
    Player player;
	size_t maxEnemies;
    int score;
}

struct Player
{
	Entity e; // player entity
	int x, y; // some position
}

struct Movable { /* some data */ }
struct Mesh { /* some data */ }

void initSystem(EntityManager em)
{
	// returns ref GameProps
	auto props = &em.resource!GameProps;

	// generates an Entity that assembles the Player
	// update GameProps
	props.player.e = em.gen!(Movable, Mesh);
	props.player.x = 16;
	props.player.y = 22;
	props.maxEnemies = 16;
	props.score = 0;
}

void main()
{
	auto em = new EntityManager();

	// instead of storing global variables with GameState and GameProps
	// they can be added to EntityManager as resources
	// the behaviour will be the same as a global variable but within EntityManager
	// so multiple EntityManagers, if one desires, can each have their own "globals instances"
	em.addResource(GameState.playing);
	em.addResource!GameProps;

	em.initSystem();
}