### PR TITLE
Fix Entity sizeof and refactor Entity

### DIFF
--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -26,41 +26,44 @@ class MaximumEntitiesReachedException : Exception { mixin basicExceptionCtors; }
 
 
 /**
- * An entity is defined by an **id** and a  **batch**. It's signature is the
- *     combination of both values. The first N bits belong to the **id** and the
- *     last M ending bits to the `batch`. \
- * \
- * An entity in it's raw form is simply an integral value formed by the junction
- *     of the id with the batch.
- * \
- * An entity is then defined by: **id | (batch << idshift)**. \
- * \
- * Let's imagine an entity of 8 bites. By default it's **id** and **batch**
- *     occupy **4 bits** each. \
- * \
- * `Entity` = **0000 0000** = ***(batch << 4) | id***.
- *
- * Constants:
- *     `idshift` = division point between the entity's **id** and **batch**. \
- *     `idmask` = bit mask related to the entity's **id** portion. \
- *     `batchmask` = bit mask related to the entity's **batch** portion. \
- *     `maxid` = the maximum number of ids allowed
- *     `maxbatch` = the maximum number of batches allowed
- *
- * Values:
- * | `void* size (bits)` | `idshift` | `idmask`    | `batchmask`       |
- * | :-----------------  | :----  -- | :---------- | :---------------- |
- * | 4                   | 20        | 0xFFFF_F    | 0xFFF << 20       |
- * | 8                   | 32        | 0xFFFF_FFFF | 0xFFFF_FFFF << 32 |
- *
- * Sizes:
- * | `void* size (bits)` | `id (bits)` | `batch (bits)` | `maxid`       | `maxbatch`    |
- * | :----------------   | :--------   | :-----------   | :------------ | :------------ |
- * | 4                   | 20          | 12             | 1_048_574     | 4_095         |
- * | 8                   | 32          | 32             | 4_294_967_295 | 4_294_967_295 |
- *
- * See_Also: [skypjack - entt](https://skypjack.github.io/2019-05-06-ecs-baf-part-3/)
- */
+An entity is defined by an `id` and `batch`. It's signature is the combination
+of both values. The **first N bits** define the `id` and the **last M bits**
+the `batch`. The signature is an integral value of 32 bits or 64 bits depending
+on the architecture. The type of this variable is `size_t` and its composition
+is divided in two parts, id and batch.
+
+Supposing an entity is an integral type of **8 bits**.
+First half defines the batch.
+Second half defines the id.
+
+Composition:
+| batch | id   |
+| :---- | :--- |
+| 0000  | 0000 |
+
+Fields:
+| name        | description                                               |
+| :---------- | :-------------------------------------------------------- |
+| `idshift`   | division point between the entity's **id** and **batch**. |
+| `idmask`    | bit mask related to the entity's **id** portion.          |
+| `batchmask` | bit mask related to the entity's **batch** portion.       |
+| `maxid`     | the maximum number of ids allowed                         |
+| `maxbatch`  | the maximum number of batches allowed                     |
+
+Values:
+| `void* size (bytes)` | `idshift (bits)` | `idmask`    | `batchmask`       |
+| :------------------- | :--------------- | :---------- | :---------------- |
+| 4                    | 20               | 0xFFFF_F    | 0xFFF << 20       |
+| 8                    | 32               | 0xFFFF_FFFF | 0xFFFF_FFFF << 32 |
+
+Sizes:
+| `void* size (bytes)` | `id (bits)` | `batch (bits)` | `maxid`       | `maxbatch`    |
+| :------------------- | :---------- | :------------- | :------------ | :------------ |
+| 4                    | 20          | 12             | 1_048_574     | 4_095         |
+| 8                    | 32          | 32             | 4_294_967_295 | 4_294_967_295 |
+
+See_Also: [skypjack - entt](https://skypjack.github.io/2019-05-06-ecs-baf-part-3/)
+*/
 struct Entity
 {
 public:
@@ -111,21 +114,21 @@ public:
 
 	static if (typeof(int.sizeof).sizeof == 4)
 	{
-		enum size_t idshift = 20UL;   // 20 bits for ids
-		enum size_t maxid = 0xFFFF_F; // 1_048_575 unique ids
-		enum size_t maxbatch = 0xFFF; // 4_095 unique batches
+		enum size_t idshift = 20UL;   /// 20 bits   or 32 bits
+		enum size_t maxid = 0xFFFF_F; /// 1_048_575 or 4_294_967_295
+		enum size_t maxbatch = 0xFFF; /// 4_095     or 4_294_967_295
 	}
 	else static if (typeof(int.sizeof).sizeof == 8)
 	{
-		enum size_t idshift = 32UL;      // 32 bits for ids
-		enum size_t maxid = 0xFFFF_FFFF; // 4_294_967_295 unique ids
-		enum size_t maxbatch = maxid;    // 4_294_967_295 unique batches
+		enum size_t idshift = 32UL;      /// ditto
+		enum size_t maxid = 0xFFFF_FFFF; /// ditto
+		enum size_t maxbatch = maxid;    /// ditto
 	}
 	else
 		static assert(false, "unsuported target");
 
-	enum size_t idmask = maxid; // first 20 bits (sizeof==4), 32 bits (sizeof==8)
-	enum size_t batchmask = maxbatch << idshift; // last 12 bits (sizeof==4), 32 bits (sizeof==8)
+	enum size_t idmask = maxid;                  /// first 20 bits or 32 bits
+	enum size_t batchmask = maxbatch << idshift; /// last  12 bits or 32 bits
 
 private:
 	@safe pure nothrow @nogc

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -149,32 +149,25 @@ private:
 @("entity: Entity")
 unittest
 {
-	auto entity0 = Entity(0);
+	assertEquals(Entity.init, Entity(0));
+	assertEquals(Entity.init, Entity(0, 0));
 
-	assertEquals(0, entity0.id);
-	assertEquals(0, entity0.batch);
-	assertEquals(0, entity0.signature);
-	assertEquals(Entity(0, 0), entity0);
+	{
+		immutable e = Entity.init;
+		assertEquals(e.id, 0);
+		assertEquals(e.batch, 0);
+		assertEquals(e.signature, 0);
+	}
 
-	entity0.incrementBatch();
-	assertEquals(0, entity0.id);
-	assertEquals(1, entity0.batch);
+	{
+		immutable e = Entity.init.incrementBatch();
+		assertEquals(e.id, 0);
+		assertEquals(e.batch, 1);
+		assertEquals(e.signature, Entity.maxid + 1);
+		assertEquals(e, Entity(0, 1));
+	}
 
-	static if (typeof(int.sizeof).sizeof == 4)
-		assertEquals(1_048_576, entity0.signature);
-	else
-		assertEquals(4_294_967_296, entity0.signature);
-
-	assertEquals(Entity(0, 1), entity0);
-
-	entity0 = Entity(0, Entity.maxbatch);
-	entity0.incrementBatch();
-	assertEquals(0, entity0.batch); // batch reseted
-
-	static if (typeof(int.sizeof).sizeof == 4)
-		assertEquals(0xFFF, Entity.maxbatch);
-	else
-		assertEquals(0xFFFF_FFFF, Entity.maxbatch);
+	assertEquals(Entity(0, Entity.maxbatch).incrementBatch().batch, 0);
 }
 
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -71,7 +71,7 @@ public:
 	this(in size_t id)
 		in (id <= maxid)
 	{
-		_id = id;
+		_signature = id;
 	}
 
 	@safe pure nothrow @nogc
@@ -79,36 +79,34 @@ public:
 		in (id <= maxid)
 		in (batch <= maxbatch)
 	{
-		_id = id;
-		_batch = batch;
+		_signature = (id | (batch << idshift));
 	}
 
 
 	@safe pure nothrow @nogc
 	bool opEquals(in Entity other) const
 	{
-		return other.signature == signature;
+		return other._signature == _signature;
 	}
 
 
 	@safe pure nothrow @nogc @property
 	size_t id() const
 	{
-		return _id;
+		return _signature & maxid;
 	}
 
 
 	@safe pure nothrow @nogc @property
 	size_t batch() const
 	{
-		return _batch;
+		return _signature >> idshift;
 	}
 
-
-	@safe pure nothrow @nogc
+	@safe pure nothrow @nogc @property
 	size_t signature() const
 	{
-		return (_id | (_batch << idshift));
+		return _signature;
 	}
 
 
@@ -134,13 +132,11 @@ private:
 	@safe pure nothrow @nogc
 	auto incrementBatch()
 	{
-		_batch = _batch >= maxbatch ? 0 : _batch + 1;
-
+		_signature = (id | ((batch + 1) << idshift));
 		return this;
 	}
 
-	size_t _id;
-	size_t _batch;
+	size_t _signature;
 }
 
 @safe pure

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -1,5 +1,12 @@
 module vecs.entity;
 
+private enum VECS_32 = typeof(int.sizeof).sizeof == 4;
+private enum VECS_64 = typeof(int.sizeof).sizeof == 8;
+static assert(VECS_32 || VECS_64, "Unsuported target!");
+
+static if (VECS_32) version = VECS_32;
+else version = VECS_64;
+
 import vecs.entitybuilder : EntityBuilder;
 import vecs.storage;
 import vecs.query;

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -117,20 +117,19 @@ public:
 	}
 
 
-	static if (typeof(int.sizeof).sizeof == 4)
+	// if size_t is 32 or 64 bits
+	version(VECS_32)
 	{
 		enum size_t idshift = 20UL;   /// 20 bits   or 32 bits
 		enum size_t maxid = 0xFFFF_F; /// 1_048_575 or 4_294_967_295
 		enum size_t maxbatch = 0xFFF; /// 4_095     or 4_294_967_295
 	}
-	else static if (typeof(int.sizeof).sizeof == 8)
+	else
 	{
 		enum size_t idshift = 32UL;      /// ditto
 		enum size_t maxid = 0xFFFF_FFFF; /// ditto
 		enum size_t maxbatch = maxid;    /// ditto
 	}
-	else
-		static assert(false, "unsuported target");
 
 	enum size_t idmask = maxid;                  /// first 20 bits or 32 bits
 	enum size_t batchmask = maxbatch << idshift; /// last  12 bits or 32 bits


### PR DESCRIPTION
* improved documentation
* added version flags VECS_32 and VECS_64
* refactored fields `_id` and `_batch` with `_signature`
* fixed functions `id`, `batch` and `signature`
* refactored conditional code with version blocks
* improved unit test readability and removed useless portions