### PR TITLE
Refactor EntityBuilder

### DIFF
--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -681,10 +681,14 @@ public:
 	 *
 	 * Returns: `EntityBuilder`.
 	 */
-	@safe pure nothrow @nogc
+	@safe pure
 	EntityBuilder entityBuilder()
 	{
-		return EntityBuilder(this);
+		EntityBuilder builder = {
+			entity: gen(),
+			em: this
+		};
+		return builder;
 	}
 
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -665,24 +665,21 @@ public:
 
 
 	/**
-	 * Returns a new builder used for chaining entity generation sequences and
-	 *     binds it to EntityManager.
+	 * Returns a new builder used for chaining entity calls.
 	 *
 	 * Examples:
 	 * ---
 	 * struct Foo {}
 	 * auto em = new EntityManager();
 	 *
-	 * // gets an EntityBuilder and generates 2 entities
-	 * em.entityBuilder()
-	 *     .gen()
-	 *     .gen!Foo();
+	 * // gets an EntityBuilder with a new entity and binds Foo to it
+	 * em.entity.set!Foo;
 	 * ---
 	 *
 	 * Returns: `EntityBuilder`.
 	 */
-	@safe pure
-	EntityBuilder entityBuilder()
+	@safe pure @property
+	EntityBuilder entity()
 	{
 		EntityBuilder builder = {
 			entity: gen(),

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -34,18 +34,18 @@ unittest
 
 	Entity[] entts;
 	with(em) entts = [
-		entityBuilder(),
-		entityBuilder(),
-		entityBuilder(),
+		entity,
+		entity,
+		entity,
 	];
 
 	assertEquals([Entity(0), Entity(1), Entity(2)], entts);
 
 	with(em) entts = [
-		entityBuilder().set!Foo,
-		entityBuilder(),
-		entityBuilder().set(Bar("str")),
-		entityBuilder().set!Foo.set!int,
+		entity.set!Foo,
+		entity,
+		entity.set(Bar("str")),
+		entity.set!Foo.set!int,
 	];
 
 	assertEquals([Entity(3), Entity(4), Entity(5), Entity(6)], entts);

--- a/source/vecs/query.d
+++ b/source/vecs/query.d
@@ -74,17 +74,18 @@ unittest
 	import std.algorithm : map;
 
 	auto em = new EntityManager();
-	em.entityBuilder()
-		.gen(Foo(2, 4), Bar.init, 4)
-		.gen!(Foo)
-		.gen!(Foo)
-		.gen!(Foo, Bar)
-		.gen!(Foo, Bar)
-		.gen!(Foo, Bar)
-		.gen!(Bar, int)
-		.gen!(Bar, int)
-		.gen!(Foo, Bar, int)
-		.gen!(Foo, Bar, int);
+	with(em) {
+		entityBuilder().set(Foo(2, 4)).set!Bar.set(4);
+		entityBuilder().set!Foo;
+		entityBuilder().set!Foo;
+		entityBuilder().set!Foo.set!Bar;
+		entityBuilder().set!Foo.set!Bar;
+		entityBuilder().set!Foo.set!Bar;
+		entityBuilder().set!Bar.set!int;
+		entityBuilder().set!Bar.set!int;
+		entityBuilder().set!Foo.set!Bar.set!int;
+		entityBuilder().set!Foo.set!Bar.set!int;
+	}
 
 	assertEquals(5, em.query!int.range.entities.length);
 	assertRangeEquals([4,0,0,0,0], em.query!int.map!"*a");
@@ -99,17 +100,18 @@ unittest
 	import std.algorithm : map;
 
 	auto em = new EntityManager();
-	em.entityBuilder()
-		.gen(Foo(2, 4), Bar.init, 4)
-		.gen!(Foo)
-		.gen!(Foo)
-		.gen!(Foo, Bar)
-		.gen!(Foo, Bar)
-		.gen!(Foo, Bar)
-		.gen!(Bar, int)
-		.gen!(Bar, int)
-		.gen!(Foo, Bar, int)
-		.gen!(Foo, Bar, int);
+	with(em) {
+		entityBuilder().set(Foo(2, 4)).set!Bar.set(4);
+		entityBuilder().set!Foo;
+		entityBuilder().set!Foo;
+		entityBuilder().set!Foo.set!Bar;
+		entityBuilder().set!Foo.set!Bar;
+		entityBuilder().set!Foo.set!Bar;
+		entityBuilder().set!Bar.set!int;
+		entityBuilder().set!Bar.set!int;
+		entityBuilder().set!Foo.set!Bar.set!int;
+		entityBuilder().set!Foo.set!Bar.set!int;
+	}
 
 	auto range = [
 		tuple(4,Bar.init),
@@ -189,17 +191,18 @@ private:
 unittest
 {
 	auto em = new EntityManager();
-	em.entityBuilder()
-		.gen(Foo(2, 4), Bar.init, 4)
-		.gen!(Foo)
-		.gen!(Foo)
-		.gen!(Foo, Bar)
-		.gen!(Foo, Bar)
-		.gen!(Foo, Bar)
-		.gen!(Bar, int)
-		.gen!(Bar, int)
-		.gen!(Foo, Bar, int)
-		.gen!(Foo, Bar, int);
+	with(em) {
+		entityBuilder().set(Foo(2, 4)).set!Bar.set(4);
+		entityBuilder().set!Foo;
+		entityBuilder().set!Foo;
+		entityBuilder().set!Foo.set!Bar;
+		entityBuilder().set!Foo.set!Bar;
+		entityBuilder().set!Foo.set!Bar;
+		entityBuilder().set!Bar.set!int;
+		entityBuilder().set!Bar.set!int;
+		entityBuilder().set!Foo.set!Bar.set!int;
+		entityBuilder().set!Foo.set!Bar.set!int;
+	}
 
 	auto range = [Entity(0),Entity(6),Entity(7),Entity(8),Entity(9)];
 	assertEquals(5, em.query!(Entity, With!int).range.entities.length);
@@ -219,17 +222,18 @@ unittest
 	import std.algorithm : map;
 
 	auto em = new EntityManager();
-	em.entityBuilder()
-		.gen(Foo(2, 4), Bar.init, 4)
-		.gen!(Foo)
-		.gen!(Foo)
-		.gen!(Foo, Bar)
-		.gen!(Foo, Bar)
-		.gen!(Foo, Bar)
-		.gen!(Bar, int)
-		.gen!(Bar, int)
-		.gen!(Foo, Bar, int)
-		.gen!(Foo, Bar, int);
+	with(em) {
+		entityBuilder().set(Foo(2, 4)).set!Bar.set(4);
+		entityBuilder().set!Foo;
+		entityBuilder().set!Foo;
+		entityBuilder().set!Foo.set!Bar;
+		entityBuilder().set!Foo.set!Bar;
+		entityBuilder().set!Foo.set!Bar;
+		entityBuilder().set!Bar.set!int;
+		entityBuilder().set!Bar.set!int;
+		entityBuilder().set!Foo.set!Bar.set!int;
+		entityBuilder().set!Foo.set!Bar.set!int;
+	}
 
 	auto range = [
 		tuple(Entity(0), 4),
@@ -261,17 +265,18 @@ unittest
 
 	{
 		auto em = new EntityManager();
-		em.entityBuilder()
-			.gen(Foo(2, 4), Bar.init, 4)
-			.gen!(Foo)
-			.gen!(Foo)
-			.gen!(Foo, Bar)
-			.gen!(Foo, Bar)
-			.gen!(Foo, Bar)
-			.gen!(Bar, int)
-			.gen!(Bar, int)
-			.gen!(Foo, Bar, int)
-			.gen!(Foo, Bar, int);
+		with(em) {
+			entityBuilder().set(Foo(2, 4)).set!Bar.set(4);
+			entityBuilder().set!Foo;
+			entityBuilder().set!Foo;
+			entityBuilder().set!Foo.set!Bar;
+			entityBuilder().set!Foo.set!Bar;
+			entityBuilder().set!Foo.set!Bar;
+			entityBuilder().set!Bar.set!int;
+			entityBuilder().set!Bar.set!int;
+			entityBuilder().set!Foo.set!Bar.set!int;
+			entityBuilder().set!Foo.set!Bar.set!int;
+		}
 
 		auto range = [4,0,0,0,0];
 		assertEquals(5, em.query!(int, With!Bar).range.entities.length);
@@ -284,10 +289,11 @@ unittest
 
 	{
 		auto em = new EntityManager();
-		em.entityBuilder()
-			.gen("Foo", 1f)
-			.gen("Bar", 1f)
-			.gen("Foobar", 1f, 5);
+		with(em) {
+			entityBuilder().set("Foo").set(1f);
+			entityBuilder().set("Bar").set(1f);
+			entityBuilder().set("Foobar").set(1f).set(5);
+		}
 
 		assertEquals(*em.query!(Tuple!(string, int)).front[0], *em.query!(string, With!int).front);
 		assertEquals(*em.query!(Tuple!(string, float, int)).front[0], *em.query!(Tuple!(string, float), With!int).front[0]);
@@ -304,17 +310,18 @@ unittest
 	import std.algorithm : map;
 
 	auto em = new EntityManager();
-	em.entityBuilder()
-		.gen(Foo(2, 4), Bar.init, 4)
-		.gen!(Foo)
-		.gen!(Foo)
-		.gen!(Foo, Bar)
-		.gen!(Foo, Bar)
-		.gen!(Foo, Bar)
-		.gen!(Bar, int)
-		.gen!(Bar, int)
-		.gen!(Foo, Bar, int)
-		.gen!(Foo, Bar, int);
+	with(em) {
+		entityBuilder().set(Foo(2, 4)).set!Bar.set(4);
+		entityBuilder().set!Foo;
+		entityBuilder().set!Foo;
+		entityBuilder().set!Foo.set!Bar;
+		entityBuilder().set!Foo.set!Bar;
+		entityBuilder().set!Foo.set!Bar;
+		entityBuilder().set!Bar.set!int;
+		entityBuilder().set!Bar.set!int;
+		entityBuilder().set!Foo.set!Bar.set!int;
+		entityBuilder().set!Foo.set!Bar.set!int;
+	}
 
 	auto range = [0,0];
 

--- a/source/vecs/query.d
+++ b/source/vecs/query.d
@@ -75,16 +75,16 @@ unittest
 
 	auto em = new EntityManager();
 	with(em) {
-		entityBuilder().set(Foo(2, 4)).set!Bar.set(4);
-		entityBuilder().set!Foo;
-		entityBuilder().set!Foo;
-		entityBuilder().set!Foo.set!Bar;
-		entityBuilder().set!Foo.set!Bar;
-		entityBuilder().set!Foo.set!Bar;
-		entityBuilder().set!Bar.set!int;
-		entityBuilder().set!Bar.set!int;
-		entityBuilder().set!Foo.set!Bar.set!int;
-		entityBuilder().set!Foo.set!Bar.set!int;
+		entity.set(Foo(2, 4)).set!Bar.set(4);
+		entity.set!Foo;
+		entity.set!Foo;
+		entity.set!Foo.set!Bar;
+		entity.set!Foo.set!Bar;
+		entity.set!Foo.set!Bar;
+		entity.set!Bar.set!int;
+		entity.set!Bar.set!int;
+		entity.set!Foo.set!Bar.set!int;
+		entity.set!Foo.set!Bar.set!int;
 	}
 
 	assertEquals(5, em.query!int.range.entities.length);
@@ -101,16 +101,16 @@ unittest
 
 	auto em = new EntityManager();
 	with(em) {
-		entityBuilder().set(Foo(2, 4)).set!Bar.set(4);
-		entityBuilder().set!Foo;
-		entityBuilder().set!Foo;
-		entityBuilder().set!Foo.set!Bar;
-		entityBuilder().set!Foo.set!Bar;
-		entityBuilder().set!Foo.set!Bar;
-		entityBuilder().set!Bar.set!int;
-		entityBuilder().set!Bar.set!int;
-		entityBuilder().set!Foo.set!Bar.set!int;
-		entityBuilder().set!Foo.set!Bar.set!int;
+		entity.set(Foo(2, 4)).set!Bar.set(4);
+		entity.set!Foo;
+		entity.set!Foo;
+		entity.set!Foo.set!Bar;
+		entity.set!Foo.set!Bar;
+		entity.set!Foo.set!Bar;
+		entity.set!Bar.set!int;
+		entity.set!Bar.set!int;
+		entity.set!Foo.set!Bar.set!int;
+		entity.set!Foo.set!Bar.set!int;
 	}
 
 	auto range = [
@@ -192,16 +192,16 @@ unittest
 {
 	auto em = new EntityManager();
 	with(em) {
-		entityBuilder().set(Foo(2, 4)).set!Bar.set(4);
-		entityBuilder().set!Foo;
-		entityBuilder().set!Foo;
-		entityBuilder().set!Foo.set!Bar;
-		entityBuilder().set!Foo.set!Bar;
-		entityBuilder().set!Foo.set!Bar;
-		entityBuilder().set!Bar.set!int;
-		entityBuilder().set!Bar.set!int;
-		entityBuilder().set!Foo.set!Bar.set!int;
-		entityBuilder().set!Foo.set!Bar.set!int;
+		entity.set(Foo(2, 4)).set!Bar.set(4);
+		entity.set!Foo;
+		entity.set!Foo;
+		entity.set!Foo.set!Bar;
+		entity.set!Foo.set!Bar;
+		entity.set!Foo.set!Bar;
+		entity.set!Bar.set!int;
+		entity.set!Bar.set!int;
+		entity.set!Foo.set!Bar.set!int;
+		entity.set!Foo.set!Bar.set!int;
 	}
 
 	auto range = [Entity(0),Entity(6),Entity(7),Entity(8),Entity(9)];
@@ -223,16 +223,16 @@ unittest
 
 	auto em = new EntityManager();
 	with(em) {
-		entityBuilder().set(Foo(2, 4)).set!Bar.set(4);
-		entityBuilder().set!Foo;
-		entityBuilder().set!Foo;
-		entityBuilder().set!Foo.set!Bar;
-		entityBuilder().set!Foo.set!Bar;
-		entityBuilder().set!Foo.set!Bar;
-		entityBuilder().set!Bar.set!int;
-		entityBuilder().set!Bar.set!int;
-		entityBuilder().set!Foo.set!Bar.set!int;
-		entityBuilder().set!Foo.set!Bar.set!int;
+		entity.set(Foo(2, 4)).set!Bar.set(4);
+		entity.set!Foo;
+		entity.set!Foo;
+		entity.set!Foo.set!Bar;
+		entity.set!Foo.set!Bar;
+		entity.set!Foo.set!Bar;
+		entity.set!Bar.set!int;
+		entity.set!Bar.set!int;
+		entity.set!Foo.set!Bar.set!int;
+		entity.set!Foo.set!Bar.set!int;
 	}
 
 	auto range = [
@@ -266,16 +266,16 @@ unittest
 	{
 		auto em = new EntityManager();
 		with(em) {
-			entityBuilder().set(Foo(2, 4)).set!Bar.set(4);
-			entityBuilder().set!Foo;
-			entityBuilder().set!Foo;
-			entityBuilder().set!Foo.set!Bar;
-			entityBuilder().set!Foo.set!Bar;
-			entityBuilder().set!Foo.set!Bar;
-			entityBuilder().set!Bar.set!int;
-			entityBuilder().set!Bar.set!int;
-			entityBuilder().set!Foo.set!Bar.set!int;
-			entityBuilder().set!Foo.set!Bar.set!int;
+			entity.set(Foo(2, 4)).set!Bar.set(4);
+			entity.set!Foo;
+			entity.set!Foo;
+			entity.set!Foo.set!Bar;
+			entity.set!Foo.set!Bar;
+			entity.set!Foo.set!Bar;
+			entity.set!Bar.set!int;
+			entity.set!Bar.set!int;
+			entity.set!Foo.set!Bar.set!int;
+			entity.set!Foo.set!Bar.set!int;
 		}
 
 		auto range = [4,0,0,0,0];
@@ -290,9 +290,9 @@ unittest
 	{
 		auto em = new EntityManager();
 		with(em) {
-			entityBuilder().set("Foo").set(1f);
-			entityBuilder().set("Bar").set(1f);
-			entityBuilder().set("Foobar").set(1f).set(5);
+			entity.set("Foo").set(1f);
+			entity.set("Bar").set(1f);
+			entity.set("Foobar").set(1f).set(5);
 		}
 
 		assertEquals(*em.query!(Tuple!(string, int)).front[0], *em.query!(string, With!int).front);
@@ -311,16 +311,16 @@ unittest
 
 	auto em = new EntityManager();
 	with(em) {
-		entityBuilder().set(Foo(2, 4)).set!Bar.set(4);
-		entityBuilder().set!Foo;
-		entityBuilder().set!Foo;
-		entityBuilder().set!Foo.set!Bar;
-		entityBuilder().set!Foo.set!Bar;
-		entityBuilder().set!Foo.set!Bar;
-		entityBuilder().set!Bar.set!int;
-		entityBuilder().set!Bar.set!int;
-		entityBuilder().set!Foo.set!Bar.set!int;
-		entityBuilder().set!Foo.set!Bar.set!int;
+		entity.set(Foo(2, 4)).set!Bar.set(4);
+		entity.set!Foo;
+		entity.set!Foo;
+		entity.set!Foo.set!Bar;
+		entity.set!Foo.set!Bar;
+		entity.set!Foo.set!Bar;
+		entity.set!Bar.set!int;
+		entity.set!Bar.set!int;
+		entity.set!Foo.set!Bar.set!int;
+		entity.set!Foo.set!Bar.set!int;
 	}
 
 	auto range = [0,0];


### PR DESCRIPTION
* replaced entities with an immutable entity
* entity is now an alias this of EntityBuilder
* removed gen functions
* added set function for a component
* fix dependent unit tests
* renamed entityBuilder to entity in EntityManager

This change breaks the following:
```d
auto world = new EntityManager();
world.entityBuilder()
	.gen()
	.gen!int
	.gen(3u, "component");
```

In favor of:
```d
auto world = new EntityManager();
Entity e = world.entity
	.set!int
	.set(3u)
	.set("component");
```

The previous logic creates 3 different entities. The current creates one and all changes alter the same entity.
To achieve the previous behavior:
```d
auto world = new EntityManager();
with(world) {
	entity;
	entity.set!int;
	entity.set(3).set("component");
}
```

The change in structure allows for future features such as:
```d
auto world = new EntityManager();

world.entity(0) // get or create, not yet implemented
	.remove!Foo
	.remove!Bar
	.set!Foobar
	.removeAll
	.discard
```