### PR TITLE
Refactor entity manager

### DIFF
--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -601,6 +601,26 @@ public:
 	}
 
 
+	// FIXME: documentation
+	@safe pure @property
+	EntityBuilder entity(in Entity e)
+	{
+		import std.algorithm : find;
+		import std.range : front, generate;
+		alias create = () => queue.isNull ? fabricate() : recycle();
+
+		// entity: generates entities until one with e.id and returns the latter
+		EntityBuilder builder = {
+			entity: has(e)
+				? _entities[e.id]
+				: generate!create.find!(entity => entity.id == e.id).front,
+			em: this
+		};
+
+		return builder;
+	}
+
+
 	/**
 	 * Checks if an entity is valid within EntityManager.
 	 *

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -865,7 +865,7 @@ public:
 		return *(() @trusted pure nothrow @nogc => cast(R*)resource.data)();
 	}
 
-private:
+
 	/**
 	 * Creates a new entity with a new id. The entity's id follows the number
 	 *     of entities created.
@@ -934,6 +934,7 @@ private:
 	}
 
 
+private:
 	// FIXME: documentation
 	@safe pure nothrow @nogc
 	Entity generateId(in size_t pos)

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -369,7 +369,7 @@ public:
 	 * Returns: `Component*` pointing to the component set either by creation or
 	 *     replacement.
 	 */
-	auto set(Components...)(in Entity e, Components components)
+	auto setComponent(Components...)(in Entity e, Components components)
 		if (Components.length)
 		in (has(e))
 	{
@@ -1217,19 +1217,19 @@ unittest
 }
 
 @system
-@("entity: EntityManager: set")
+@("entity: EntityManager: setComponent")
 unittest
 {
 	auto em = new EntityManager();
 
 	auto e = em.entity();
-	assertTrue(em.set(e, Foo(4, 5)));
-	assertThrown!AssertError(em.set(Entity(0, 5), Foo(4, 5)));
-	assertThrown!AssertError(em.set(Entity(2), Foo(4, 5)));
+	assertTrue(em.setComponent(e, Foo(4, 5)));
+	assertThrown!AssertError(em.setComponent(Entity(0, 5), Foo(4, 5)));
+	assertThrown!AssertError(em.setComponent(Entity(2), Foo(4, 5)));
 	assertEquals(Foo(4, 5), *em.storageInfoMap[ComponentId!Foo].get!(Foo).get(e));
 
 	{
-		auto components = em.set(em.entity(), Foo(4, 5), Bar("str"));
+		auto components = em.setComponent(em.entity(), Foo(4, 5), Bar("str"));
 		assertEquals(Foo(4,5), *components[0]);
 		assertEquals(Bar("str"), *components[1]);
 	}
@@ -1243,7 +1243,7 @@ unittest
 
 	assertThrown!AssertError(em.addComponent!Foo(Entity(45)));
 	assertThrown!AssertError(em.addComponent!(Foo, Bar)(Entity(45)));
-	assertThrown!AssertError(em.set(Entity(45), Foo.init, Bar.init));
+	assertThrown!AssertError(em.setComponent(Entity(45), Foo.init, Bar.init));
 }
 
 @system

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -597,6 +597,7 @@ public:
 			entity: queue.isNull ? fabricate() : recycle(),
 			em: this
 		};
+
 		return builder;
 	}
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -239,6 +239,23 @@ public:
 	}
 
 
+	// FIXME: documentation
+	@safe pure nothrow @nogc
+	bool shallowEntity(in Entity e)
+		in (has(e))
+	{
+		import std.algorithm : filter;
+
+		auto range = storageInfoMap.filter!(sinfo => sinfo.storage !is null);
+
+		foreach (sinfo; range)
+			if (sinfo.has(e))
+				return false;
+
+		return true;
+	}
+
+
 	/**
 	 * This signal occurs every time a Component is set. The onSet signal is
 	 *     emitted **after** the Component is set. A Component is set when

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -235,6 +235,14 @@ public:
 	}
 
 
+	// FIXME: documentation
+	void destroyEntity(in Entity e, in size_t batch)
+	{
+		removeAllComponents(e);
+		releaseId(e, batch);
+	}
+
+
 	/**
 	 * This signal occurs every time a Component is set. The onSet signal is
 	 *     emitted **after** the Component is set. A Component is set when

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -720,7 +720,7 @@ public:
 	{
 		EntityBuilder builder = {
 			entity: createEntity(),
-			em: this
+			entityManager: this
 		};
 
 		return builder;
@@ -733,7 +733,7 @@ public:
 	{
 		EntityBuilder builder = {
 			entity: createEntity(hint),
-			em: this
+			entityManager: this
 		};
 
 		return builder;

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -473,7 +473,7 @@ public:
 	{
 		foreach (sinfo; storageInfoMap)
 			if (sinfo.storage !is null)
-				sinfo.tryRemove(e);
+				sinfo.remove(e);
 	}
 
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -183,6 +183,14 @@ public:
 
 
 	// FIXME: documentation
+	void registerComponent(Components...)()
+		if (Components.length)
+	{
+		static foreach (Component; Components) _assure!Component;
+	}
+
+
+	// FIXME: documentation
 	auto addComponent(Components...)(in Entity e)
 		if (Components.length)
 		in (validEntity(e))

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -861,6 +861,16 @@ private:
 	}
 
 
+	// FIXME: documentation
+	@safe pure nothrow @nogc
+	void releaseId(in Entity e, in size_t batch)
+		in (batch <= Entity.maxbatch)
+	{
+		_entities[e.id] = queue.isNull ? entityNull : queue.get();
+		queue = Entity(e.id, batch);
+	}
+
+
 	/// Assures the Component's storage availability
 	size_t _assure(Component)()
 		if (isComponent!Component)

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -380,14 +380,14 @@ public:
 	 * auto em = new EntityManager();
 	 *
 	 * // disassociates Foo from the newly generated entity
-	 * em.remove!Foo(em.gen!Foo());
+	 * em.removeComponent!Foo(em.gen!Foo());
 	 * ---
 	 *
 	 * Params:
 	 *     e = entity to disassociate.
 	 *     Component = component to remove.
 	 */
-	void remove(Component)(in Entity e)
+	void removeComponent(Component)(in Entity e)
 		in (has(e))
 	{
 		_assureStorageInfo!Component.remove(e);
@@ -408,8 +408,8 @@ public:
 	 * auto em = new EntityManager();
 	 *
 	 * // might lead to undefined behavior
-	 * em.remove!Foo(em.entityNull);
-	 * em.remove!Foo(em.gen());
+	 * em.removeComponent!Foo(em.entityNull);
+	 * em.removeComponent!Foo(em.gen());
 	 *
 	 * // safely tries to remove Foo from an entity
 	 * em.removeIfHas!Foo(em.entityNull);
@@ -1106,7 +1106,7 @@ unittest
 {
 	auto em = new EntityManager();
 	em.onRemove!Foo.connect((Entity,Foo* foo) { assertEquals(Foo(7, 8), *foo); });
-	em.remove!Foo(em.entity().set(Foo(7, 8)));
+	em.removeComponent!Foo(em.entity().set(Foo(7, 8)));
 }
 
 @system
@@ -1143,25 +1143,25 @@ unittest
 	auto em = new EntityManager();
 
 	auto e = em.entity().add!(Foo, Bar, int);
-	assertThrown!AssertError(em.remove!size_t(e)); // not in the storageInfoMap
+	assertThrown!AssertError(em.removeComponent!size_t(e)); // not in the storageInfoMap
 
-	em.remove!Foo(e); // removes Foo
-	assertThrown!AssertError(em.remove!Foo(e)); // e does not contain Foo
+	em.removeComponent!Foo(e); // removes Foo
+	assertThrown!AssertError(em.removeComponent!Foo(e)); // e does not contain Foo
 	assertThrown!AssertError(em.storageInfoMap[ComponentId!Foo].get!(Foo).get(e));
 
 	// removes only if associated
 	em.removeAll(e); // removes int
 	em.removeAll(e); // doesn't remove any
 
-	assertThrown!AssertError(em.remove!Foo(e)); // e does not contain Foo
-	assertThrown!AssertError(em.remove!Bar(e)); // e does not contain Bar
-	assertThrown!AssertError(em.remove!int(e)); // e does not contain ValidImmutable
+	assertThrown!AssertError(em.removeComponent!Foo(e)); // e does not contain Foo
+	assertThrown!AssertError(em.removeComponent!Bar(e)); // e does not contain Bar
+	assertThrown!AssertError(em.removeComponent!int(e)); // e does not contain ValidImmutable
 
 	// invalid entity
 	assertThrown!AssertError(em.removeAll(Entity(15)));
 
 	// cannot call with invalid components
-	assertFalse(__traits(compiles, em.remove!(void delegate())(e)));
+	assertFalse(__traits(compiles, em.removeComponent!(void delegate())(e)));
 }
 
 @system
@@ -1217,6 +1217,6 @@ unittest
 	assertEquals(1, em.size!Foo());
 	assertEquals(0, em.size!Bar());
 
-	em.remove!Foo(e);
+	em.removeComponent!Foo(e);
 	assertEquals(0, em.size!Foo());
 }

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -266,7 +266,7 @@ public:
 		auto range = storageInfoMap.filter!(sinfo => sinfo.storage !is null);
 
 		foreach (sinfo; range)
-			if (sinfo.has(e))
+			if (sinfo.contains(e))
 				return false;
 
 		return true;

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -258,6 +258,22 @@ public:
 
 	// FIXME: documentation
 	@safe pure nothrow @nogc
+	size_t aliveEntities()
+	{
+		if (queue.isNull) return _entities.length;
+
+		auto alive = _entities.length - 1;
+
+		// search all destroyed entities
+		for (auto e = _entities[queue.id]; e != entityNull; alive--)
+			e = _entities[e.id];
+
+		return alive;
+	}
+
+
+	// FIXME: documentation
+	@safe pure nothrow @nogc
 	bool shallowEntity(in Entity e)
 		in (validEntity(e))
 	{

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -387,10 +387,19 @@ public:
 	 *     e = entity to disassociate.
 	 *     Component = component to remove.
 	 */
-	void removeComponent(Components...)(in Entity e)
+	auto removeComponent(Components...)(in Entity e)
+		if (Components.length)
 		in (has(e))
 	{
-		static foreach (Component; Components) _assureStorageInfo!Component.remove(e);
+		import std.meta : Repeat;
+		Repeat!(Components.length, bool) R; // removed components
+
+		static foreach (i, Component; Components) R[i] = _assureStorageInfo!Component.remove(e);
+
+		static if (Components.length == 1)
+			return R[0];
+		else
+			return [R];
 	}
 
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -832,6 +832,17 @@ private:
 	}
 
 
+	// FIXME: documentation
+	@safe pure nothrow @nogc
+	Entity generateId(in size_t pos)
+	{
+		static immutable err = "Maximum entities (" ~ Entity.maxid.stringof ~ ") reached!";
+		if (pos >= Entity.maxid) assert(false, err);
+
+		return Entity(pos);
+	}
+
+
 	/**
 	 * Creates a new entity reusing the id of a **previously discarded entity**
 	 *     with a new batch. Swaps the current discarded entity stored the

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -497,12 +497,12 @@ public:
 	 * auto em = new EntityManager();
 	 *
 	 * // gets Foo from the newly generated entity
-	 * em.get!Foo(em.gen!Foo());
+	 * em.getComponent!Foo(em.gen!Foo());
 	 * ---
 	 *
 	 * Returns: `Component*` pointing to the component fetched.
 	 */
-	Component* get(Component)(in Entity e)
+	Component* getComponent(Component)(in Entity e)
 		in (has(e))
 	{
 		return _assureStorage!Component().get(e);
@@ -1081,14 +1081,14 @@ unittest
 
 	auto e = em.entity().add!(Foo, Bar);
 
-	assertEquals(Foo.init, *em.get!Foo(e));
-	assertEquals(Bar.init, *em.get!Bar(e));
-	assertThrown!AssertError(em.get!int(e));
+	assertEquals(Foo.init, *em.getComponent!Foo(e));
+	assertEquals(Bar.init, *em.getComponent!Bar(e));
+	assertThrown!AssertError(em.getComponent!int(e));
 
-	em.get!Foo(e).y = 10;
-	assertEquals(Foo(int.init, 10), *em.get!Foo(e));
+	em.getComponent!Foo(e).y = 10;
+	assertEquals(Foo(int.init, 10), *em.getComponent!Foo(e));
 
-	assertFalse(__traits(compiles, em.get!(immutable(int))(em.entity())));
+	assertFalse(__traits(compiles, em.getComponent!(immutable(int))(em.entity())));
 }
 
 @system
@@ -1123,7 +1123,7 @@ unittest
 	em.onSet!Foo.connect((Entity,Foo* foo) { *foo = Foo(12, 3); });
 
 	em.entity().add!Foo;
-	assertEquals(Foo(12,3), *em.get!Foo(Entity(0)));
+	assertEquals(Foo(12,3), *em.getComponent!Foo(Entity(0)));
 }
 
 @system

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -594,7 +594,7 @@ public:
 	EntityBuilder entity()
 	{
 		EntityBuilder builder = {
-			entity: queue.isNull ? fabricate() : recycleId(),
+			entity: createEntity(),
 			em: this
 		};
 
@@ -815,14 +815,16 @@ private:
 	 * Returns: `Entity` newly created or asserts is maximum is reached.
 	 */
 	@safe pure nothrow
-	Entity fabricate()
+	Entity createEntity()
 	{
-		enum err = "Maximum entities (" ~ Entity.maxid.stringof ~ ") reached!";
-		if (_entities.length >= Entity.maxid) assert(false, err);
+		if (queue.isNull)
+		{
+			import std.range : back;
+			_entities ~= generateId(_entities.length);
+			return _entities.back;
+		}
 
-		import std.range : back;
-		_entities ~= Entity(_entities.length);
-		return _entities.back;
+		else return recycleId();
 	}
 
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -420,7 +420,7 @@ public:
 	 *     e = entity to disassociate.
 	 *     Component = component to remove.
 	 */
-	void removeIfHas(Component)(in Entity e)
+	void tryRemoveComponent(Component)(in Entity e)
 	{
 		if (has(e)) _assureStorageInfo!Component().tryRemove(e);
 	}

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -228,7 +228,7 @@ public:
 	void destroyEntity(in Entity e)
 		in (has(e))
 	{
-		removeAll(e);                                              // remove all components
+		removeAllComponents(e);                                              // remove all components
 		_entities[e.id] = queue.isNull ? entityNull : queue.get(); // move the next in queue to back
 		queue = e;                                                 // update the next in queue
 		queue.incrementBatch();                                    // increment batch for when it's revived
@@ -459,7 +459,7 @@ public:
 	 *     e = entity to disassociate.
 	 */
 	@system
-	void removeAll(in Entity e)
+	void removeAllComponents(in Entity e)
 		in (has(e))
 	{
 		foreach (sinfo; storageInfoMap)
@@ -1153,15 +1153,15 @@ unittest
 	assertThrown!AssertError(em.storageInfoMap[ComponentId!Foo].get!(Foo).get(e));
 
 	// removes only if associated
-	em.removeAll(e); // removes int
-	em.removeAll(e); // doesn't remove any
+	em.removeAllComponents(e); // removes int
+	em.removeAllComponents(e); // doesn't remove any
 
 	assertThrown!AssertError(em.removeComponent!Foo(e)); // e does not contain Foo
 	assertThrown!AssertError(em.removeComponent!Bar(e)); // e does not contain Bar
 	assertThrown!AssertError(em.removeComponent!int(e)); // e does not contain ValidImmutable
 
 	// invalid entity
-	assertThrown!AssertError(em.removeAll(Entity(15)));
+	assertThrown!AssertError(em.removeAllComponents(Entity(15)));
 
 	// cannot call with invalid components
 	assertFalse(__traits(compiles, em.removeComponent!(void delegate())(e)));

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -823,14 +823,6 @@ private:
 	}
 
 
-	/// Common logic for remove dependencies
-	void _remove(Component)(in Entity entity)
-		if (isComponent!Component)
-	{
-		_assureStorage!Component().remove(entity);
-	}
-
-
 	/// Assures the Component's storage availability
 	size_t _assure(Component)()
 		if (isComponent!Component)

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -209,6 +209,15 @@ public:
 
 
 	// FIXME: documentation
+	@safe pure nothrow @nogc
+	void releaseEntity(in Entity e, in size_t batch)
+		in (shallowEntity(e))
+	{
+		releaseId(e, batch);
+	}
+
+
+	// FIXME: documentation
 	/**
 	 * Destroys a valid entity. When destroyed all the associated components are
 	 *     removed. Passig an invalid entity leads to undefined behaviour.

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -226,12 +226,8 @@ public:
 	 */
 	@system
 	void destroyEntity(in Entity e)
-		in (has(e))
 	{
-		removeAllComponents(e);                                              // remove all components
-		_entities[e.id] = queue.isNull ? entityNull : queue.get(); // move the next in queue to back
-		queue = e;                                                 // update the next in queue
-		queue.incrementBatch();                                    // increment batch for when it's revived
+		destroyEntity(e, (e.batch + 1) & Entity.maxbatch);
 	}
 
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -475,7 +475,7 @@ public:
 	void removeAll(Component)()
 	{
 		// FIXME: emit onRemove
-		_assureStorage!Component().removeAll();
+		_assureStorage!Component().clear();
 	}
 
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -420,9 +420,12 @@ public:
 	 *     e = entity to disassociate.
 	 *     Component = component to remove.
 	 */
-	void tryRemoveComponent(Component)(in Entity e)
+	void tryRemoveComponent(Components...)(in Entity e)
 	{
-		if (has(e)) _assureStorageInfo!Component().tryRemove(e);
+		if (has(e))
+		{
+			static foreach (Component; Components) _assureStorageInfo!Component.tryRemove(e);
+		}
 	}
 
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -404,41 +404,6 @@ public:
 
 
 	/**
-	 * Safely tries to disassociate an entity from a component. If invalid does
-	 *     nothing.
-	 *
-	 * Safety: The **internal code** is @safe, however, because of **Signal**
-	 *     dependency, the method must be @system.
-	 *
-	 * Signal: Emits onRemove **before** disassociating the component.
-	 *
-	 * Examples:
-	 * ---
-	 * auto em = new EntityManager();
-	 *
-	 * // might lead to undefined behavior
-	 * em.removeComponent!Foo(em.entityNull);
-	 * em.removeComponent!Foo(em.gen());
-	 *
-	 * // safely tries to remove Foo from an entity
-	 * em.removeIfHas!Foo(em.entityNull);
-	 * em.removeIfHas!Foo(em.gen());
-	 * ---
-	 *
-	 * Params:
-	 *     e = entity to disassociate.
-	 *     Component = component to remove.
-	 */
-	void tryRemoveComponent(Components...)(in Entity e)
-	{
-		if (has(e))
-		{
-			static foreach (Component; Components) _assureStorageInfo!Component.tryRemove(e);
-		}
-	}
-
-
-	/**
 	 * Removes all components associated to an entity. Passing an invalid entity
 	 *     leads to undefined behaviour. If a component is passed instead, it
 	 *     clears the storage of the same disassociating every entity in it.

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -185,7 +185,7 @@ public:
 	// FIXME: documentation
 	auto addComponent(Components...)(in Entity e)
 		if (Components.length)
-		in (has(e))
+		in (validEntity(e))
 	{
 		import std.meta : staticMap;
 		alias PointerOf(T) = T*;
@@ -202,7 +202,7 @@ public:
 
 	// FIXME: documentation
 	Component* emplaceComponent(Component, Args...)(in Entity e, auto ref Args args)
-		in (has(e))
+		in (validEntity(e))
 	{
 		return _assureStorage!Component.emplace(e, args);
 	}
@@ -259,7 +259,7 @@ public:
 	// FIXME: documentation
 	@safe pure nothrow @nogc
 	bool shallowEntity(in Entity e)
-		in (has(e))
+		in (validEntity(e))
 	{
 		import std.algorithm : filter;
 
@@ -387,7 +387,7 @@ public:
 	 */
 	auto setComponent(Components...)(in Entity e, Components components)
 		if (Components.length)
-		in (has(e))
+		in (validEntity(e))
 	{
 		import std.meta : staticMap;
 		alias PointerOf(T) = T*;
@@ -427,7 +427,7 @@ public:
 	 */
 	auto removeComponent(Components...)(in Entity e)
 		if (Components.length)
-		in (has(e))
+		in (validEntity(e))
 	{
 		import std.meta : Repeat;
 		Repeat!(Components.length, bool) R; // removed components
@@ -472,7 +472,7 @@ public:
 	 */
 	@system
 	void removeAllComponents(in Entity e)
-		in (has(e))
+		in (validEntity(e))
 	{
 		foreach (sinfo; storageInfoMap)
 			if (sinfo.storage !is null)
@@ -517,7 +517,7 @@ public:
 	 */
 	auto getComponent(Components...)(in Entity e)
 		if (Components.length)
-		in (has(e))
+		in (validEntity(e))
 	{
 		import std.meta : staticMap;
 		alias PointerOf(T) = T*;
@@ -535,7 +535,7 @@ public:
 	// FIXME: documentation
 	auto tryGetComponent(Components...)(in Entity e)
 		if (Components.length)
-		in (has(e))
+		in (validEntity(e))
 	{
 		import std.meta : staticMap;
 		alias PointerOf(T) = T*;
@@ -581,7 +581,7 @@ public:
 	 * Returns: `Component*` pointing to the component associated.
 	 */
 	Component* getOrSet(Component)(in Entity e, Component component = Component.init)
-		in (has(e))
+		in (validEntity(e))
 	{
 		return _assureStorage!Component().getOrSet(e, component);
 	}
@@ -663,7 +663,7 @@ public:
 	 * Returns: `true` if the entity exists, `false` otherwise.
 	 */
 	@safe pure nothrow @nogc
-	bool has(in Entity e) const
+	bool validEntity(in Entity e) const
 		in (e.id < Entity.maxid)
 	{
 		return e.id < _entities.length && _entities[e.id] == e;

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -606,15 +606,9 @@ public:
 	@safe pure @property
 	EntityBuilder entity(in Entity e)
 	{
-		import std.algorithm : find;
-		import std.range : front, generate;
-		alias create = () => queue.isNull ? fabricate() : recycleId();
-
 		// entity: generates entities until one with e.id and returns the latter
 		EntityBuilder builder = {
-			entity: has(e)
-				? _entities[e.id]
-				: generate!create.find!(entity => entity.id == e.id).front,
+			entity: createEntity(e),
 			em: this
 		};
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -520,7 +520,22 @@ public:
 	}
 
 
-	// TODO: getIfHas to safely try to get a component from an entity
+	// FIXME: documentation
+	auto tryGetComponent(Components...)(in Entity e)
+		if (Components.length)
+		in (has(e))
+	{
+		import std.meta : staticMap;
+		alias PointerOf(T) = T*;
+		staticMap!(PointerOf, Components) C;
+
+		static foreach (i, Component; Components) C[i] = _assureStorage!Component.tryGet(e);
+
+		static if (Components.length == 1)
+			return C[0];
+		else
+			return tuple(C);
+	}
 
 
 	/**

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -236,29 +236,6 @@ public:
 
 
 	/**
-	 * Safely tries to discard an entity. If invalid does nothing.
-	 *
-	 * Params:
-	 *     e = entity to discard.
-	 *
-	 * Examples:
-	 * ---
-	 * auto em = new EntityManager();
-	 *
-	 * // might lead to undefined behavior
-	 * em.destroyEntity(em.entityNull);
-	 *
-	 * // safely tries to discard an entity
-	 * em.destroyEntity(em.entityNull);
-	 * ---
-	 */
-	void discardIfHas(in Entity e)
-	{
-		if (has(e)) destroyEntity(e);
-	}
-
-
-	/**
 	 * This signal occurs every time a Component is set. The onSet signal is
 	 *     emitted **after** the Component is set. A Component is set when
 	 *     assigning a new one to an entity or when updating an existing one.

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -796,22 +796,19 @@ public:
 	auto queryOne(Output, Filter)() { return query!(Output, Filter).front; }
 
 
+	// FIXME: documentation
 	/**
 	 * Gets every entity currently alive/existent within EntityManager.
 	 *
 	 * Returns: `Entity[]` of alive/existent entities.
 	 */
-	@safe pure nothrow @property
-	Entity[] entities() const
+	void eachEntity(F)(F fun) const
 	{
-		import std.array : appender;
-		auto ret = appender!(Entity[]);
+		if (queue.isNull)
+			foreach (i, entity; _entities) fun(entity);
 
-		foreach (i, e; _entities)
-			if (e.id == i)
-				ret ~= e;
-
-		return ret.data;
+		else
+			foreach (i, entity; _entities) if (entity.id == i) fun(entity);
 	}
 
 
@@ -1139,7 +1136,12 @@ private:
 	Entity[] _queryEntities(ComponentRange ...)()
 	{
 		static if (ComponentRange.length == 0)
-			return entities();
+		{
+			Entity[] ret;
+			ret.reserve(aliveEntities());
+			eachEntity((const Entity entity) { ret ~= entity; });
+			return ret;
+		}
 		else
 		{
 			import std.algorithm : minElement;

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -471,11 +471,14 @@ public:
 	// TODO: removeAllIfHas to safely try to remove from an entity
 
 
-	/// Ditto
-	void removeAll(Component)()
+	// FIXME: documentation
+	void removeAll(Components...)()
 	{
-		// FIXME: emit onRemove
-		_assureStorage!Component().clear();
+		static if (Components.length)
+			static foreach (Component; Components) _assureStorageInfo!Component().clear();
+
+		else
+			foreach (sinfo; storageInfoMap) if (sinfo.storage) sinfo.clear();
 	}
 
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -823,15 +823,6 @@ private:
 	}
 
 
-	/// Common logic for set dependencies
-	Component* _set(Component)(in Entity entity, Component component = Component.init)
-		if (isComponent!Component)
-	{
-		// set the component to entity
-		return _assureStorage!Component().set(entity, component);
-	}
-
-
 	/// Common logic for remove dependencies
 	void _remove(Component)(in Entity entity)
 		if (isComponent!Component)

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -651,7 +651,7 @@ public:
 	 *
 	 * Returns: `EntityBuilder`.
 	 */
-	@safe pure @property
+	@safe pure nothrow @property
 	EntityBuilder entity()
 	{
 		EntityBuilder builder = {
@@ -664,7 +664,7 @@ public:
 
 
 	// FIXME: documentation
-	@safe pure @property
+	@safe pure nothrow @property
 	EntityBuilder entity(in Entity e)
 	{
 		// entity: generates entities until one with e.id and returns the latter

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -1186,17 +1186,15 @@ unittest
 	auto e = em.entity().add!(Foo, Bar, int);
 	em.removeComponent!size_t(e); // not in the storageInfoMap
 
-	em.removeComponent!Foo(e); // removes Foo
-	em.removeComponent!Foo(e); // e does not contain Foo
+	assertTrue(em.removeComponent!Foo(e)); // removes Foo
+	assertFalse(em.removeComponent!Foo(e)); // e does not contain Foo
 	assertThrown!AssertError(em.storageInfoMap[ComponentId!Foo].get!(Foo).get(e));
 
 	// removes only if associated
 	em.removeAllComponents(e); // removes int
 	em.removeAllComponents(e); // doesn't remove any
 
-	em.removeComponent!Foo(e); // e does not contain Foo
-	em.removeComponent!Bar(e); // e does not contain Bar
-	em.removeComponent!int(e); // e does not contain ValidImmutable
+	assertEquals([false, false, false], em.removeComponent!(Foo, Bar, int)(e));
 
 	// invalid entity
 	assertThrown!AssertError(em.removeAllComponents(Entity(15)));

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -461,7 +461,7 @@ public:
 	{
 		foreach (sinfo; storageInfoMap)
 			if (sinfo.storage !is null)
-				sinfo.removeIfHas(e);
+				sinfo.tryRemove(e);
 	}
 
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -594,7 +594,7 @@ public:
 	EntityBuilder entity()
 	{
 		EntityBuilder builder = {
-			entity: queue.isNull ? fabricate() : recycle(),
+			entity: queue.isNull ? fabricate() : recycleId(),
 			em: this
 		};
 
@@ -608,7 +608,7 @@ public:
 	{
 		import std.algorithm : find;
 		import std.range : front, generate;
-		alias create = () => queue.isNull ? fabricate() : recycle();
+		alias create = () => queue.isNull ? fabricate() : recycleId();
 
 		// entity: generates entities until one with e.id and returns the latter
 		EntityBuilder builder = {
@@ -840,7 +840,7 @@ private:
 	 * Returns: `Entity` newly created.
 	 */
 	@safe pure nothrow @nogc
-	Entity recycle()
+	Entity recycleId()
 		in (!queue.isNull)
 	{
 		immutable next = queue;     // get the next entity in queue

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -210,6 +210,14 @@ public:
 
 	// FIXME: documentation
 	@safe pure nothrow @nogc
+	void releaseEntity(in Entity e)
+	{
+		releaseEntity(e, (e.batch + 1) & Entity.maxbatch);
+	}
+
+
+	// FIXME: documentation
+	@safe pure nothrow @nogc
 	void releaseEntity(in Entity e, in size_t batch)
 		in (shallowEntity(e))
 	{

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -422,7 +422,7 @@ public:
 	 */
 	void removeIfHas(Component)(in Entity e)
 	{
-		if (has(e)) _assureStorage!Component().removeIfHas(e);
+		if (has(e)) _assureStorage!Component().tryRemove(e);
 	}
 
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -390,7 +390,7 @@ public:
 	void remove(Component)(in Entity e)
 		in (has(e))
 	{
-		_remove!Component(e);
+		_assureStorageInfo!Component.remove(e);
 	}
 
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -200,6 +200,14 @@ public:
 	}
 
 
+	// FIXME: documentation
+	Component* emplaceComponent(Component, Args...)(in Entity e, auto ref Args args)
+		in (has(e))
+	{
+		return _assureStorage!Component.emplace(e, args);
+	}
+
+
 	/**
 	 * Destroys a valid entity. When destroyed all the associated components are
 	 *     removed. Passig an invalid entity leads to undefined behaviour.

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -482,6 +482,7 @@ public:
 	}
 
 
+	// FIXME: documentation
 	/**
 	 * Fetch a component associated to an entity. The entity must be associated
 	 *     with the Component passed. Passing an invalid entity leads to
@@ -502,10 +503,20 @@ public:
 	 *
 	 * Returns: `Component*` pointing to the component fetched.
 	 */
-	Component* getComponent(Component)(in Entity e)
+	auto getComponent(Components...)(in Entity e)
+		if (Components.length)
 		in (has(e))
 	{
-		return _assureStorage!Component().get(e);
+		import std.meta : staticMap;
+		alias PointerOf(T) = T*;
+		staticMap!(PointerOf, Components) C;
+
+		static foreach (i, Component; Components) C[i] = _assureStorage!Component.get(e);
+
+		static if (Components.length == 1)
+			return C[0];
+		else
+			return tuple(C);
 	}
 
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -422,7 +422,7 @@ public:
 	 */
 	void removeIfHas(Component)(in Entity e)
 	{
-		if (has(e)) _assureStorage!Component().tryRemove(e);
+		if (has(e)) _assureStorageInfo!Component().tryRemove(e);
 	}
 
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -387,10 +387,10 @@ public:
 	 *     e = entity to disassociate.
 	 *     Component = component to remove.
 	 */
-	void removeComponent(Component)(in Entity e)
+	void removeComponent(Components...)(in Entity e)
 		in (has(e))
 	{
-		_assureStorageInfo!Component.remove(e);
+		static foreach (Component; Components) _assureStorageInfo!Component.remove(e);
 	}
 
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -208,6 +208,7 @@ public:
 	}
 
 
+	// FIXME: documentation
 	/**
 	 * Destroys a valid entity. When destroyed all the associated components are
 	 *     removed. Passig an invalid entity leads to undefined behaviour.
@@ -220,11 +221,11 @@ public:
 	 * auto em = new EntityManager();
 	 *
 	 * // discards the newly generated entity
-	 * em.discard(em.gen());
+	 * em.destroyEntity(em.gen());
 	 * ---
 	 */
 	@system
-	void discard(in Entity e)
+	void destroyEntity(in Entity e)
 		in (has(e))
 	{
 		removeAll(e);                                              // remove all components
@@ -245,15 +246,15 @@ public:
 	 * auto em = new EntityManager();
 	 *
 	 * // might lead to undefined behavior
-	 * em.discard(em.entityNull);
+	 * em.destroyEntity(em.entityNull);
 	 *
 	 * // safely tries to discard an entity
-	 * em.discardIfHas(em.entityNull);
+	 * em.destroyEntity(em.entityNull);
 	 * ---
 	 */
 	void discardIfHas(in Entity e)
 	{
-		if (has(e)) discard(e);
+		if (has(e)) destroyEntity(e);
 	}
 
 
@@ -316,14 +317,14 @@ public:
 	 * em.onSet!Foo().connect(fun);
 	 *
 	 * // this emits onRemove
-	 * em.discard(em.gen!Foo());
+	 * em.destroyEntity(em.gen!Foo());
 	 *
 	 * assert(1 == i);
 	 *
 	 * // unbind a callback
 	 * em.onSet!Foo().disconnect(fun);
 	 *
-	 * em.discard(em.gen!Foo());
+	 * em.destroyEntity(em.gen!Foo());
 	 * assert(1 == i);
 	 * ---
 	 *
@@ -1059,18 +1060,18 @@ unittest
 	auto entity2 = em.entity();
 
 
-	em.discard(entity1);
+	em.destroyEntity(entity1);
 	assertFalse(em.queue.isNull);
 	assertEquals(em.entityNull, em._entities[entity1.id]);
 	(() @trusted pure => assertEquals(Entity(1, 1), em.queue.get))(); // batch was incremented
 
-	em.discard(entity0);
+	em.destroyEntity(entity0);
 	assertEquals(Entity(1, 1), em._entities[entity0.id]);
 	(() @trusted pure => assertEquals(Entity(0, 1), em.queue.get))(); // batch was incremented
 
 	// cannot discard invalid entities
-	assertThrown!AssertError(em.discard(Entity(50)));
-	assertThrown!AssertError(em.discard(Entity(entity2.id, 40)));
+	assertThrown!AssertError(em.destroyEntity(Entity(50)));
+	assertThrown!AssertError(em.destroyEntity(Entity(entity2.id, 40)));
 
 	assertEquals(3, em._entities.length);
 }
@@ -1083,7 +1084,7 @@ unittest
 	auto em = new EntityManager();
 
 	auto entity0 = em.entity(); // calls fabricate
-	em.discard(entity0); // discards
+	em.destroyEntity(entity0); // discards
 	em.entity(); // recycles
 	assertTrue(em.queue.isNull);
 
@@ -1167,7 +1168,7 @@ unittest
 	auto em = new EntityManager();
 
 	auto entity0 = em.entity(); // calls fabricate
-	em.discard(entity0); // discards
+	em.destroyEntity(entity0); // discards
 	(() @trusted pure => assertEquals(Entity(0, 1), em.queue.get))(); // batch was incremented
 	assertFalse(Entity(0, 1) == entity0); // entity's batch is not updated
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -472,7 +472,7 @@ public:
 
 
 	// FIXME: documentation
-	void removeAll(Components...)()
+	void clear(Components...)()
 	{
 		static if (Components.length)
 			static foreach (Component; Components) _assureStorageInfo!Component().clear();
@@ -1179,7 +1179,7 @@ unittest
 	foreach (i; 0..10) em.entity().add!(Foo, Bar);
 
 	assertEquals(10, em.size!Foo());
-	em.removeAll!Foo();
+	em.clear!Foo();
 	assertEquals(0, em.size!Foo());
 }
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -338,6 +338,7 @@ public:
 	}
 
 
+	// FIXME: documentation
 	/**
 	 * Associates an entity to a component. Passing an invalid entity leads to
 	 *     undefined behaviour. Emits onSet after associating the component to
@@ -368,23 +369,20 @@ public:
 	 * Returns: `Component*` pointing to the component set either by creation or
 	 *     replacement.
 	 */
-	Component* set(Component)(in Entity e, Component component)
+	auto set(Components...)(in Entity e, Components components)
+		if (Components.length)
 		in (has(e))
 	{
-		return _set(e, component);
-	}
+		import std.meta : staticMap;
+		alias PointerOf(T) = T*;
+		staticMap!(PointerOf, Components) C;
 
+		static foreach (i, Component; Components) C[i] = _assureStorage!Component.set(e, components[i]);
 
-	/// Ditto
-	auto set(ComponentRange ...)(in Entity e, ComponentRange components)
-		if (ComponentRange.length > 1 && is(ComponentRange == NoDuplicates!ComponentRange))
-		in (has(e))
-	{
-		mixin(format!q{Tuple!(%(ComponentRange[%s]*%|, %)) ret;}(ComponentRange.length.iota));
-
-		foreach (i, component; components) ret[i] = _set(e, component);
-
-		return ret;
+		static if (Components.length == 1)
+			return C[0];
+		else
+			return tuple(C);
 	}
 
 

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -1175,19 +1175,19 @@ unittest
 	auto em = new EntityManager();
 
 	auto e = em.entity().add!(Foo, Bar, int);
-	assertThrown!AssertError(em.removeComponent!size_t(e)); // not in the storageInfoMap
+	em.removeComponent!size_t(e); // not in the storageInfoMap
 
 	em.removeComponent!Foo(e); // removes Foo
-	assertThrown!AssertError(em.removeComponent!Foo(e)); // e does not contain Foo
+	em.removeComponent!Foo(e); // e does not contain Foo
 	assertThrown!AssertError(em.storageInfoMap[ComponentId!Foo].get!(Foo).get(e));
 
 	// removes only if associated
 	em.removeAllComponents(e); // removes int
 	em.removeAllComponents(e); // doesn't remove any
 
-	assertThrown!AssertError(em.removeComponent!Foo(e)); // e does not contain Foo
-	assertThrown!AssertError(em.removeComponent!Bar(e)); // e does not contain Bar
-	assertThrown!AssertError(em.removeComponent!int(e)); // e does not contain ValidImmutable
+	em.removeComponent!Foo(e); // e does not contain Foo
+	em.removeComponent!Bar(e); // e does not contain Bar
+	em.removeComponent!int(e); // e does not contain ValidImmutable
 
 	// invalid entity
 	assertThrown!AssertError(em.removeAllComponents(Entity(15)));

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -26,9 +26,9 @@ public:
 	}
 
 	// FIXME: documentation
-	EntityBuilder set(Component)(Component component)
+	EntityBuilder set(Components...)(Components components)
 	{
-		em.set!Component(entity, component);
+		em.set!Components(entity, components);
 		return this;
 	}
 

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -32,6 +32,12 @@ public:
 		return this;
 	}
 
+	// FIXME: documentation
+	EntityBuilder remove(Components...)()
+	{
+		em.removeComponent!Components(entity);
+		return this;
+	}
 
 	// FIXME: documentation
 	EntityBuilder destroy()()

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -120,6 +120,5 @@ public:
 	immutable Entity entity = EntityManager.entityNull;
 	alias entity this;
 
-package:
 	EntityManager em;
 }

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -116,6 +116,13 @@ public:
 		return this;
 	}
 
+	/// Ditto
+	EntityBuilder destroy()(in size_t batch)
+	{
+		entityManager.destroyEntity(entity, batch);
+		return this;
+	}
+
 
 	Entity entity = EntityManager.entityNull;
 	alias entity this;

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -26,7 +26,7 @@ public:
 	*/
 	EntityBuilder add(Components...)()
 	{
-		em.addComponent!Components(entity);
+		entityManager.addComponent!Components(entity);
 		return this;
 	}
 
@@ -46,7 +46,7 @@ public:
 	*/
 	EntityBuilder emplace(Component, Args...)(auto ref Args args)
 	{
-		em.emplaceComponent!Component(entity, args);
+		entityManager.emplaceComponent!Component(entity, args);
 		return this;
 	}
 
@@ -64,7 +64,7 @@ public:
 	*/
 	EntityBuilder set(Components...)(Components components)
 	{
-		em.setComponent!Components(entity, components);
+		entityManager.setComponent!Components(entity, components);
 		return this;
 	}
 
@@ -82,7 +82,7 @@ public:
 	*/
 	EntityBuilder remove(Components...)()
 	{
-		em.removeComponent!Components(entity);
+		entityManager.removeComponent!Components(entity);
 		return this;
 	}
 
@@ -97,7 +97,7 @@ public:
 	*/
 	EntityBuilder removeAll()()
 	{
-		em.removeAllComponents(entity);
+		entityManager.removeAllComponents(entity);
 		return this;
 	}
 
@@ -112,7 +112,7 @@ public:
 	*/
 	EntityBuilder destroy()()
 	{
-		em.destroyEntity(entity);
+		entityManager.destroyEntity(entity);
 		return this;
 	}
 
@@ -120,5 +120,5 @@ public:
 	immutable Entity entity = EntityManager.entityNull;
 	alias entity this;
 
-	EntityManager em;
+	EntityManager entityManager;
 }

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -33,6 +33,14 @@ public:
 	}
 
 
+	// FIXME: documentation
+	EntityBuilder destroy()()
+	{
+		em.destroyEntity(entity);
+		return this;
+	}
+
+
 	immutable Entity entity = EntityManager.entityNull;
 	alias entity this;
 

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -126,6 +126,30 @@ public:
 		return this;
 	}
 
+	/**
+	Releases a `shallow entity`. It's `id` is released and the `batch` is updated
+	to be ready for the next recycling.
+
+	Attempting to use an invalid entity leads to undefined behavior.
+
+	Params:
+		batch = batch to update upon release.
+
+	Returns: This instance.
+	*/
+	EntityBuilder release()()
+	{
+		entityManager.releaseEntity(entity);
+		return this;
+	}
+
+	/// Ditto
+	EntityBuilder release()(in size_t batch)
+	{
+		entityManager.releaseEntity(entity, batch);
+		return this;
+	}
+
 
 	Entity entity = EntityManager.entityNull;
 	alias entity this;

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -60,29 +60,3 @@ public:
 package:
 	EntityManager em;
 }
-
-@system
-@("entitybuilder: entityBuilder")
-unittest
-{
-	import vecs.storage;
-	EntityManager em = new EntityManager();
-
-	Entity[] entts;
-	with(em) entts = [
-		entity,
-		entity,
-		entity,
-	];
-
-	assertEquals([Entity(0), Entity(1), Entity(2)], entts);
-
-	with(em) entts = [
-		entity.add!Foo,
-		entity,
-		entity.set(Bar("str")),
-		entity.add!(Foo, int),
-	];
-
-	assertEquals([Entity(3), Entity(4), Entity(5), Entity(6)], entts);
-}

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -117,7 +117,7 @@ public:
 	}
 
 
-	immutable Entity entity = EntityManager.entityNull;
+	Entity entity = EntityManager.entityNull;
 	alias entity this;
 
 	EntityManager entityManager;

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -108,6 +108,9 @@ public:
 
 	Signal: emits `onRemove` before each component is removed.
 
+	Params:
+		batch = batch to update upon release.
+
 	Returns: This instance.
 	*/
 	EntityBuilder destroy()()

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -19,6 +19,13 @@ public:
 	}
 
 	// FIXME: documentation
+	EntityBuilder emplace(Component, Args...)(auto ref Args args)
+	{
+		em.emplaceComponent!Component(entity, args);
+		return this;
+	}
+
+	// FIXME: documentation
 	EntityBuilder set(Component)(Component component)
 	{
 		em.set!Component(entity, component);

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -11,42 +11,105 @@ version(vecs_unittest) import aurorafw.unit.assertion;
 struct EntityBuilder
 {
 public:
-	// FIXME: documentation
+	/**
+	Add `Components` to an `entity`. `Components` are contructed according to
+	their dafault initializer.
+
+	Attempting to use an invalid entity leads to undefined behavior.
+
+	Signal: emits `onSet` after each component is assigned.
+
+	Params:
+		Components = Component types to add.
+
+	Returns: This instance.
+	*/
 	EntityBuilder add(Components...)()
 	{
 		em.addComponent!Components(entity);
 		return this;
 	}
 
-	// FIXME: documentation
+	/**
+	Assigns the `Component` to the `entity`. The `Component` is initialized with
+	the `args` provided.
+
+	Attempting to use an invalid entity leads to undefined behavior.
+
+	Signal: emits `onSet` after each component is assigned.
+
+	Params:
+		Component = Component type to emplace.
+		args = arguments to contruct the Component type.
+
+	Returns: This instance.
+	*/
 	EntityBuilder emplace(Component, Args...)(auto ref Args args)
 	{
 		em.emplaceComponent!Component(entity, args);
 		return this;
 	}
 
-	// FIXME: documentation
+	/**
+	Assigns the components to an entity.
+
+	Attempting to use an invalid entity leads to undefined behavior.
+
+	Signal: emits `onSet` after each component is assigned.
+
+	Params:
+		components = components to assign.
+
+	Returns: This instance.
+	*/
 	EntityBuilder set(Components...)(Components components)
 	{
 		em.setComponent!Components(entity, components);
 		return this;
 	}
 
-	// FIXME: documentation
+	/**
+	Removes components from an entity.
+
+	Attempting to use an invalid entity leads to undefined behavior.
+
+	Signal: emits $(LREF onRemove) before each component is removed.
+
+	Params:
+		Components = Component types to remove.
+
+	Returns: This instance.
+	*/
 	EntityBuilder remove(Components...)()
 	{
 		em.removeComponent!Components(entity);
 		return this;
 	}
 
-	// FIXME: documentation
+	/**
+	Removes all components from an entity.
+
+	Attempting to use an invalid entity leads to undefined behavior.
+
+	Signal: emits $(LREF onRemove) before each component is removed.
+
+	Returns: This instance.
+	*/
 	EntityBuilder removeAll()()
 	{
 		em.removeAllComponents(entity);
 		return this;
 	}
 
-	// FIXME: documentation
+	/**
+	Removes all components from an entity and releases it.
+
+	Attempting to use an invalid entity leads to undefined behavior.
+
+	Signal: emits `onRemove` before each component is removed.
+
+	Returns: This instance.
+	*/
 	EntityBuilder destroy()()
 	{
 		em.destroyEntity(entity);

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -28,7 +28,7 @@ public:
 	// FIXME: documentation
 	EntityBuilder set(Components...)(Components components)
 	{
-		em.set!Components(entity, components);
+		em.setComponent!Components(entity, components);
 		return this;
 	}
 

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -40,6 +40,13 @@ public:
 	}
 
 	// FIXME: documentation
+	EntityBuilder removeAll()()
+	{
+		em.removeAllComponents(entity);
+		return this;
+	}
+
+	// FIXME: documentation
 	EntityBuilder destroy()()
 	{
 		em.destroyEntity(entity);

--- a/source/vecs/query.d
+++ b/source/vecs/query.d
@@ -11,7 +11,12 @@ import std.range : iota;
 import std.traits : isInstanceOf, staticMap, TemplateArgsOf;
 import std.typecons : Tuple, tuple;
 
-version(vecs_unittest) import aurorafw.unit.assertion;
+version(vecs_unittest)
+{
+	import aurorafw.unit.assertion;
+	struct Foo { int x, y; }
+	struct Bar { string str; }
+}
 
 struct Query(Output)
 {

--- a/source/vecs/query.d
+++ b/source/vecs/query.d
@@ -54,13 +54,13 @@ unittest
 	auto em = new EntityManager();
 	11.iota.each!(i => em.entity());
 
-	em.discard(Entity(2));
-	em.discard(Entity(3));
-	em.discard(Entity(5));
-	em.discard(Entity(6));
-	em.discard(Entity(7));
-	em.discard(Entity(9));
-	em.discard(Entity(10));
+	em.destroyEntity(Entity(2));
+	em.destroyEntity(Entity(3));
+	em.destroyEntity(Entity(5));
+	em.destroyEntity(Entity(6));
+	em.destroyEntity(Entity(7));
+	em.destroyEntity(Entity(9));
+	em.destroyEntity(Entity(10));
 
 	assertRangeEquals([Entity(0),Entity(1),Entity(4),Entity(8)], em.query!Entity);
 	assertRangeEquals(em.query!(Tuple!Entity), em.query!Entity);

--- a/source/vecs/queryfilter.d
+++ b/source/vecs/queryfilter.d
@@ -30,7 +30,7 @@ package:
 	bool opCall(in Entity e)
 	{
 		foreach (sinfo; sinfos)
-			if (!sinfo.has(e))
+			if (!sinfo.contains(e))
 				return false;
 
 		return true;
@@ -57,7 +57,7 @@ package:
 	bool opCall(in Entity e)
 	{
 		foreach (sinfo; sinfos)
-			if (sinfo.has(e))
+			if (sinfo.contains(e))
 				return false;
 
 		return true;

--- a/source/vecs/queryworld.d
+++ b/source/vecs/queryworld.d
@@ -99,7 +99,7 @@ package struct QueryWorld(OutputTuple)
 	bool _validate()
 	{
 		foreach (sinfo; sinfos)
-			if (!sinfo.has(entities[0]))
+			if (!sinfo.contains(entities[0]))
 				return false;
 
 		return true;

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -391,6 +391,14 @@ package class Storage(Component)
 	}
 
 
+	// FIXME: documentation
+	@safe pure nothrow @nogc
+	Component* tryGet(in Entity e)
+	{
+		return has(e) ? get(e) : null;
+	}
+
+
 	/**
 	 * Fetch the component if associated to the entity, otherwise the component
 	 *     passed set then returned. Emits onSet if the component is set.

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -194,7 +194,7 @@ public:
 
 		(() @trusted pure nothrow @nogc => this.storage = cast(void*) storage)();
 		this.entities = &storage.entities;
-		this.has = &storage.has;
+		this.has = &storage.contains;
 		this.remove = &storage.remove;
 		this.clear = &storage.clear;
 		this.size = &storage.size;
@@ -325,7 +325,7 @@ package class Storage(Component)
 	@system
 	bool remove(in Entity e)
 	{
-		if (!has(e)) return false;
+		if (!contains(e)) return false;
 
 		import std.algorithm : swap;
 		import std.range : back, popBack;
@@ -374,7 +374,7 @@ package class Storage(Component)
 	 */
 	@safe pure nothrow @nogc
 	Component* get(in Entity e)
-		in (has(e))
+		in (contains(e))
 	{
 		return &_components[_sparsedEntities[e.id]];
 	}
@@ -384,7 +384,7 @@ package class Storage(Component)
 	@safe pure nothrow @nogc
 	Component* tryGet(in Entity e)
 	{
-		return has(e) ? get(e) : null;
+		return contains(e) ? get(e) : null;
 	}
 
 
@@ -411,7 +411,7 @@ package class Storage(Component)
 			&&_packedEntities[_sparsedEntities[e.id]].batch != e.batch)
 		)
 	{
-		return has(e) ? get(e) : set(e, component);
+		return contains(e) ? get(e) : set(e, component);
 	}
 
 
@@ -436,7 +436,7 @@ package class Storage(Component)
 	 * Returns:`true` if exists, `false` otherwise.
 	 */
 	@safe pure nothrow @nogc
-	bool has(in Entity e) const
+	bool contains(in Entity e) const
 	{
 		return e.id < _sparsedEntities.length
 			&& _sparsedEntities[e.id] < _packedEntities.length
@@ -479,7 +479,7 @@ private:
 			&& _packedEntities[_sparsedEntities[e.id]].batch != e.batch
 		))
 	{
-		if (!has(e))
+		if (!contains(e))
 		{
 			_packedEntities ~= e; // set entity
 			_components.length++;

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -196,7 +196,7 @@ public:
 		this.entities = &storage.entities;
 		this.has = &storage.has;
 		this.remove = &storage.remove;
-		this.removeAll = &storage.removeAll;
+		this.removeAll = &storage.clear;
 		this.tryRemove = &storage.tryRemove;
 		this.size = &storage.size;
 	}
@@ -210,7 +210,7 @@ public:
 
 	bool delegate(in Entity e) @safe pure nothrow @nogc const has;
 	void delegate(in Entity e) @system remove;
-	void delegate() @trusted pure removeAll;
+	void delegate() @safe pure nothrow removeAll;
 	void delegate(in Entity e) @system tryRemove;
 	size_t delegate() @safe pure nothrow @nogc @property const size;
 
@@ -364,8 +364,8 @@ package class Storage(Component)
 	/**
 	 * Clears all components and entities.
 	 */
-	@trusted pure
-	void removeAll()
+	@safe pure nothrow
+	void clear()
 	{
 		// FIXME: emit onRemove
 		_sparsedEntities = [];

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -197,7 +197,7 @@ public:
 		this.has = &storage.has;
 		this.remove = &storage.remove;
 		this.removeAll = &storage.removeAll;
-		this.removeIfHas = &storage.removeIfHas;
+		this.removeIfHas = &storage.tryRemove;
 		this.size = &storage.size;
 	}
 
@@ -355,7 +355,7 @@ package class Storage(Component)
 	 *     e = entity to disassociate.
 	 */
 	@system
-	void removeIfHas(in Entity e)
+	void tryRemove(in Entity e)
 	{
 		if (has(e)) remove(e);
 	}

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -351,19 +351,6 @@ package class Storage(Component)
 
 
 	/**
-	 * Disassociates a component from an entity if existent in Storage.
-	 *
-	 * Params:
-	 *     e = entity to disassociate.
-	 */
-	@system
-	void tryRemove(in Entity e)
-	{
-		if (has(e)) remove(e);
-	}
-
-
-	/**
 	 * Clears all components and entities.
 	 */
 	@safe pure nothrow

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -197,7 +197,7 @@ public:
 		this.has = &storage.has;
 		this.remove = &storage.remove;
 		this.removeAll = &storage.removeAll;
-		this.removeIfHas = &storage.tryRemove;
+		this.tryRemove = &storage.tryRemove;
 		this.size = &storage.size;
 	}
 
@@ -211,7 +211,7 @@ public:
 	bool delegate(in Entity e) @safe pure nothrow @nogc const has;
 	void delegate(in Entity e) @system remove;
 	void delegate() @trusted pure removeAll;
-	void delegate(in Entity e) @system removeIfHas;
+	void delegate(in Entity e) @system tryRemove;
 	size_t delegate() @safe pure nothrow @nogc @property const size;
 
 

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -196,7 +196,7 @@ public:
 		this.entities = &storage.entities;
 		this.has = &storage.has;
 		this.remove = &storage.remove;
-		this.removeAll = &storage.clear;
+		this.clear = &storage.clear;
 		this.tryRemove = &storage.tryRemove;
 		this.size = &storage.size;
 	}
@@ -210,7 +210,7 @@ public:
 
 	bool delegate(in Entity e) @safe pure nothrow @nogc const has;
 	void delegate(in Entity e) @system remove;
-	void delegate() @safe pure nothrow removeAll;
+	void delegate() @safe pure nothrow clear;
 	void delegate(in Entity e) @system tryRemove;
 	size_t delegate() @safe pure nothrow @nogc @property const size;
 

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -194,7 +194,7 @@ public:
 
 		(() @trusted pure nothrow @nogc => this.storage = cast(void*) storage)();
 		this.entities = &storage.entities;
-		this.has = &storage.contains;
+		this.contains = &storage.contains;
 		this.remove = &storage.remove;
 		this.clear = &storage.clear;
 		this.size = &storage.size;
@@ -207,7 +207,7 @@ public:
 		return (() @trusted pure nothrow @nogc => cast(Storage!Component) storage)(); // safe cast
 	}
 
-	bool delegate(in Entity e) @safe pure nothrow @nogc const has;
+	bool delegate(in Entity e) @safe pure nothrow @nogc const contains;
 	bool delegate(in Entity e) @system remove;
 	void delegate() @safe pure nothrow clear;
 	size_t delegate() @safe pure nothrow @nogc @property const size;

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -209,7 +209,7 @@ public:
 	}
 
 	bool delegate(in Entity e) @safe pure nothrow @nogc const has;
-	void delegate(in Entity e) @system remove;
+	bool delegate(in Entity e) @system remove;
 	void delegate() @safe pure nothrow clear;
 	void delegate(in Entity e) @system tryRemove;
 	size_t delegate() @safe pure nothrow @nogc @property const size;
@@ -246,7 +246,7 @@ unittest
 	assertEquals(1, storage._packedEntities.length);
 	assertEquals(Entity(0), storage._packedEntities.front);
 
-	assertThrown!AssertError(storage.remove(Entity(0, 45)));
+	assertFalse(storage.remove(Entity(0, 45)));
 
 	storage.remove(Entity(0));
 	assertEquals(0, storage._packedEntities.length);
@@ -312,6 +312,7 @@ package class Storage(Component)
 	}
 
 
+	// FIXME: documentation
 	/**
 	 * Disassociates an entity from it's component. Passing an invalid entity
 	 *     leads to undefined behaviour.
@@ -324,9 +325,10 @@ package class Storage(Component)
 	 * Params: e = the entity to disassociate from it's component.
 	 */
 	@system
-	void remove(in Entity e)
-		in (has(e))
+	bool remove(in Entity e)
 	{
+		if (!has(e)) return false;
+
 		import std.algorithm : swap;
 		import std.range : back, popBack;
 
@@ -345,6 +347,8 @@ package class Storage(Component)
 		// remove the last element
 		_components.popBack;
 		_packedEntities.popBack;
+
+		return true;
 	}
 
 
@@ -601,8 +605,8 @@ unittest
 	storage.set(Entity(0), Bar("bar"));
 	storage.set(Entity(1), Bar("bar"));
 
-	assertThrown!AssertError(storage.remove(Entity(0, 5)));
-	assertThrown!AssertError(storage.remove(Entity(42)));
+	assertFalse(storage.remove(Entity(0, 5)));
+	assertFalse(storage.remove(Entity(42)));
 
 	storage.remove(Entity(0));
 	assertEquals(1, storage._sparsedEntities[0]);

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -197,7 +197,6 @@ public:
 		this.has = &storage.has;
 		this.remove = &storage.remove;
 		this.clear = &storage.clear;
-		this.tryRemove = &storage.tryRemove;
 		this.size = &storage.size;
 	}
 
@@ -211,7 +210,6 @@ public:
 	bool delegate(in Entity e) @safe pure nothrow @nogc const has;
 	bool delegate(in Entity e) @system remove;
 	void delegate() @safe pure nothrow clear;
-	void delegate(in Entity e) @system tryRemove;
 	size_t delegate() @safe pure nothrow @nogc @property const size;
 
 


### PR DESCRIPTION
Changes:
* multiple name changes
* implemented a bunch of new functions
* refactored existent functions

## Storage:
* implemented `add`, `set`, `emplace`
* implemented `tryGet`
* refactored `set`, `remove`
* renamed`has` to `contains`
* renamed `removeAll` to `clear`
* removed `removeIfHas`

## StorageInfo:
* renamed `removeAll` to `clear`
* renamed `has` to `contains`
* removed `removeIfHas`

## EntityManager
* renamed `entityBuilder` to `entity`
* renamed `discard` to `destroyEntity`
* renamed `has` to `valid`
* renamed `remove` to `removeComponent`
* renamed `removeAll` to `clear` and `removeAllComponents`
* renamed `get` to `getComponent`
* renamed `entities` to `eachEntity`
* refactored `entityBuilder`
* refactored `fabricate` and `recycle`, this functions are now `createEntity`, `generateId`, `recycleId`
* refactored `destroyEntity`
* refactored `set`
* refactored `removeComponent`
* refactored `clear`
* refactored `eachEntity` to forward each valid entity to a function
* refactored `createEntity` to be public
* implemented `releaseId`
* implemented `addComponent`, `setComponent`, `emplaceComponent`
* implemented `releaseEntity`
* implemented `shallowEntity`
* implemented `aliveEntities`
* implemented `tryGetComponent`
* implemented `registerComponent`
* removed `MaximumEntitiesReachedException`
* removed `gen`
* removed `removeIfHas`

## EntityBuilder
* implemented `add`, `set`, `emplace`, `remove`, `removeAll`, `destroy`

The majority of this PR focuses on improving code readability and comprehension. Some of the changes can are demonstrated below:
```d
auto world = new EntityManager();

// components can now be registered
with (world) {
	registerComponent!int;
	registerComponent!(byte, string); // multiple components allowed
}

// entity builder is now much more useful
auto entity = world.entity
	.add!int // add an init state component
	.emplace!string("Hello Entity") // construct directly into the component array
	.set(64u)
	.remove!int
	.remove!(uint, string); // remove now accepts a range

// entities with specific ids can now be requested
world.entity(Entity(45));

// if the entity is alive it returns it instead of creating a new one
assert(entity == world.entity(Entity(0)));

// a custom batch can now be chosen when destroying an entity
// the next time this entity gets recycled its batch will be 7
// entity builder's entity implicitly casts to entity so that it can be used with entity manager functions
world.destroyEntity(entity, 7);
assert(world.entity.batch == 7);

auto shallow = world.createEntity();

// entity manager now informs if an entity is shallow
// a shallow entity holds no components
assert(world.shallowEntity(shallow));

// shallow entities can be released, better performance than destroy
world.releaseEntity(shallow);

// when releasing the next batch can be chosen
world.releaseEntity(world.createEntity(), 87);

// entity manager now informs the number of entities alive
assert(world.aliveEntities() == 1);
```
