### PR TITLE
Fix signal - allow safe pure nothrow in VECS

### DIFF
--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -15,6 +15,11 @@ struct EntityBuilder(EntityManagerT)
 	if (isInstanceOf!(.EntityManagerT, EntityManagerT))
 {
 public:
+	bool opEquals(R)(in R other) const
+	{
+		return entity == other;
+	}
+
 	/**
 	Add `Components` to an `entity`. `Components` are contructed according to
 	their dafault initializer.

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -3,13 +3,16 @@ module vecs.entitybuilder;
 import vecs.entity;
 import vecs.entitymanager;
 
+import std.traits : isInstanceOf;
+
 version(vecs_unittest) import aurorafw.unit.assertion;
 
 
 /**
  * Helper struct to perform multiple action sequences.
  */
-struct EntityBuilder
+struct EntityBuilder(EntityManagerT)
+	if (isInstanceOf!(.EntityManagerT, EntityManagerT))
 {
 public:
 	/**
@@ -155,5 +158,5 @@ public:
 	Entity entity = nullentity;
 	alias entity this;
 
-	EntityManager entityManager;
+	EntityManagerT entityManager;
 }

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -388,9 +388,11 @@ public:
 	void removeAllComponents()(in Entity e)
 		in (validEntity(e))
 	{
+		import std.traits : functionAttributes, SetFunctionAttributes;
+
 		foreach (sinfo; storageInfoMap)
 			if (sinfo.storage !is null)
-				sinfo.remove(e);
+				(() @trusted => cast(SetFunctionAttributes!(typeof(sinfo.remove), "D", functionAttributes!Fun)) sinfo.remove)()(e);
 	}
 
 

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -22,13 +22,13 @@ version(vecs_unittest)
 	import core.exception : AssertError;
 }
 
-alias EntityManager = EntityManagerImpl!(void delegate() @safe);
+alias EntityManager = EntityManagerT!(void delegate() @safe);
 
 /**
  * Responsible for managing all entities lifetime and access to components as
  *     well as any operation related to them.
  */
-class EntityManagerImpl(Fun)
+class EntityManagerT(Fun)
 	if(is(Fun : void delegate()))
 {
 public:

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -22,12 +22,14 @@ version(vecs_unittest)
 	import core.exception : AssertError;
 }
 
+alias EntityManager = EntityManagerImpl!(void delegate() @safe);
 
 /**
  * Responsible for managing all entities lifetime and access to components as
  *     well as any operation related to them.
  */
-class EntityManager
+class EntityManagerImpl(Fun)
+	if(is(Fun : void delegate()))
 {
 public:
 	/**

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -924,7 +924,7 @@ private:
 
 
 	/// Assures the Component's storage availability and returns the Storage
-	Storage!Component _assureStorage(Component)()
+	Storage!(Component, Fun) _assureStorage(Component)()
 		if (isComponent!Component)
 	{
 		immutable index = _assure!Component(); // to fix dmd boundscheck=off

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -916,7 +916,7 @@ private:
 		// creates a storage if there is none of Component
 		if (storageInfoMap[index].storage is null)
 		{
-			storageInfoMap[index] = StorageInfo().__ctor!(Component)();
+			storageInfoMap[index] = StorageInfo().__ctor!(Component, Fun)();
 		}
 
 		return index;

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -366,7 +366,7 @@ public:
 		import std.meta : Repeat;
 		Repeat!(Components.length, bool) R; // removed components
 
-		static foreach (i, Component; Components) R[i] = _assureStorageInfo!Component.remove(entity);
+		static foreach (i, Component; Components) R[i] = _assureStorage!Component.remove(entity);
 
 		static if (Components.length == 1)
 			return R[0];

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -1087,9 +1087,9 @@ private:
 }
 
 @("[EntityManager] component operations (adding and updating)")
-unittest
+@safe pure nothrow unittest
 {
-	scope world = new EntityManager();
+	scope world = new EntityManagerT!(void delegate() @safe pure nothrow @nogc);
 
 	assert(*world.addComponent!int(world.entity) == 0);
 	assert(*world.emplaceComponent!int(world.entity, 34) == 34);
@@ -1146,9 +1146,9 @@ unittest
 }
 
 @("[EntityManager] component operations (register and remove)")
-unittest
+@safe pure nothrow unittest
 {
-	scope world = new EntityManager();
+	scope world = new EntityManagerT!(void delegate() @safe pure nothrow @nogc);
 
 	world.registerComponent!(int, string, ulong);
 
@@ -1188,9 +1188,9 @@ unittest
 }
 
 @("[EntityManager] entity manipulation (entity properties)")
-unittest
+@safe pure nothrow unittest
 {
-	scope world = new EntityManager();
+	scope world = new EntityManagerT!(void delegate() @safe pure nothrow @nogc);
 
 	auto entity = world.entity();
 
@@ -1205,9 +1205,9 @@ unittest
 }
 
 @("[EntityManager] entity manipulation (generated and recycled)")
-unittest
+@safe pure nothrow unittest
 {
-	scope world = new EntityManager();
+	scope world = new EntityManagerT!(void delegate() @safe pure nothrow @nogc);
 
 	assert(!world._entities);
 
@@ -1249,9 +1249,9 @@ unittest
 }
 
 @("[EntityManager] entity manipulation (queue properties)")
-unittest
+@safe pure nothrow unittest
 {
-	scope world = new EntityManager();
+	scope world = new EntityManagerT!(void delegate() @safe pure nothrow @nogc);
 
 	assert(world.queue == nullentity);
 
@@ -1262,9 +1262,9 @@ unittest
 }
 
 @("[EntityManager] entity manipulation (request batches on destruction and release)")
-unittest
+@safe pure nothrow unittest
 {
-	scope world = new EntityManager();
+	scope world = new EntityManagerT!(void delegate() @safe pure nothrow @nogc);
 	immutable eid = 4;
 
 	world.destroyEntity(world.entity(Entity(eid)), 78);
@@ -1281,9 +1281,9 @@ unittest
 }
 
 @("[EntityManager] entity manipulation (request ids and batches on construction)")
-unittest
+@safe pure nothrow unittest
 {
-	scope world = new EntityManager();
+	scope world = new EntityManagerT!(void delegate() @safe pure nothrow @nogc);
 	auto entity = world.entity(Entity(5, 78));
 
 	assert(entity.id == 5);

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -565,9 +565,9 @@ public:
 	Returns: The created or in use entity wrapped in an EntityBuilder.
 	*/
 	@safe pure nothrow @property
-	EntityBuilder entity()
+	EntityBuilder!EntityManagerT entity()
 	{
-		EntityBuilder builder = {
+		EntityBuilder!EntityManagerT builder = {
 			entity: createEntity(),
 			entityManager: this
 		};
@@ -578,9 +578,9 @@ public:
 
 	/// Ditto
 	@safe pure nothrow @property
-	EntityBuilder entity(in Entity hint)
+	EntityBuilder!EntityManagerT entity(in Entity hint)
 	{
-		EntityBuilder builder = {
+		EntityBuilder!EntityManagerT builder = {
 			entity: createEntity(hint),
 			entityManager: this
 		};

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -156,15 +156,14 @@ public:
 
 	See_Also: $(LREF releaseEntity), $(LREF removeAll)
 	*/
-	@system
-	void destroyEntity(in Entity entity)
+	void destroyEntity()(in Entity entity)
 	{
 		destroyEntity(entity, (entity.batch + 1) & Entity.maxbatch);
 	}
 
 
 	/// Ditto
-	void destroyEntity(in Entity e, in size_t batch)
+	void destroyEntity()(in Entity e, in size_t batch)
 	{
 		removeAllComponents(e);
 		releaseId(e, batch);
@@ -386,8 +385,7 @@ public:
 	Params:
 		entity = a valid entity.
 	*/
-	@system
-	void removeAllComponents(in Entity e)
+	void removeAllComponents()(in Entity e)
 		in (validEntity(e))
 	{
 		foreach (sinfo; storageInfoMap)

--- a/source/vecs/query.d
+++ b/source/vecs/query.d
@@ -19,11 +19,11 @@ version(vecs_unittest)
 	struct Bar { string str; }
 }
 
-struct Query(Output)
+struct Query(EntityManagerT, Output)
 {
 package:
 	@safe pure nothrow @nogc
-	this(QueryWorld!Output range)
+	this(QueryWorld!(EntityManagerT, Output) range)
 	{
 		this.range = range;
 	}
@@ -48,7 +48,7 @@ public:
 	}
 
 private:
-	QueryWorld!Output range;
+	QueryWorld!(EntityManagerT, Output) range;
 }
 
 @system
@@ -142,11 +142,11 @@ unittest
 }
 
 
-struct Query(Output, Filter)
+struct Query(EntityManagerT, Output, Filter)
 {
 package:
 	@safe pure nothrow @nogc
-	this(QueryWorld!Output range, QueryFilter!Filter filter)
+	this(QueryWorld!(EntityManagerT, Output) range, QueryFilter!Filter filter)
 	{
 		this.range = range;
 		this.filter = filter;
@@ -188,7 +188,7 @@ private:
 		return filter.validate(range.entities[0]);
 	}
 
-	QueryWorld!Output range;
+	QueryWorld!(EntityManagerT, Output) range;
 	QueryFilter!Filter filter;
 }
 

--- a/source/vecs/queryworld.d
+++ b/source/vecs/queryworld.d
@@ -10,7 +10,7 @@ import std.traits : isInstanceOf, TemplateArgsOf;
 import std.typecons : Tuple, tuple;
 
 
-package struct QueryWorld(Output : Entity)
+package struct QueryWorld(EntityManagerT, Output : Entity)
 {
 	@safe pure nothrow @nogc
 	this(immutable Entity[] entities)
@@ -40,10 +40,10 @@ package struct QueryWorld(Output : Entity)
 }
 
 
-alias QueryWorld(T : Tuple!Entity) = QueryWorld!Entity;
+alias QueryWorld(EntityManagerT, T : Tuple!Entity) = QueryWorld!(EntityManagerT, Entity);
 
 
-package struct QueryWorld(Output)
+package struct QueryWorld(EntityManagerT, Output)
 	if (isComponent!Output)
 {
 	@safe pure nothrow @nogc
@@ -78,7 +78,7 @@ package struct QueryWorld(Output)
 }
 
 
-package struct QueryWorld(OutputTuple)
+package struct QueryWorld(EntityManagerT, OutputTuple)
 	if (isInstanceOf!(Tuple, OutputTuple))
 {
 	@safe pure nothrow @nogc
@@ -124,13 +124,14 @@ package struct QueryWorld(OutputTuple)
 	auto front()
 	{
 		immutable e = entities[0];
-		enum components = format!q{%(sinfos[%s].get!(Components[%s]).get(e)%|,%)}(Components.length.iota);
+		enum components = format!q{%(sinfos[%s].get!(Components[%s], Fun).get(e)%|,%)}(Components.length.iota);
 		static if (is(Out[0] == Entity))
 			return mixin(format!q{tuple(e, %s)}(components));
 		else
 			return mixin(format!q{tuple(%s)}(components));
 	}
 
+	alias Fun = TemplateArgsOf!EntityManagerT[0];
 	alias Out = TemplateArgsOf!OutputTuple;
 	static if (is(Out[0] == Entity))
 		alias Components = Out[1..$];

--- a/source/vecs/signal.d
+++ b/source/vecs/signal.d
@@ -32,7 +32,10 @@ struct SignalT(Slot)
 
 	void connect(Slot slot)
 	{
-		slots ~= slot;
+		import std.algorithm : canFind;
+
+		if (!slots.canFind(slot))
+			slots ~= slot;
 	}
 
 

--- a/source/vecs/signal.d
+++ b/source/vecs/signal.d
@@ -30,13 +30,12 @@ struct SignalT(Slot)
 	}
 
 
-	@safe pure nothrow
 	void connect(Slot slot)
 	{
 		slots ~= slot;
 	}
 
-	@safe pure nothrow
+
 	void disconnect(Slot slot)
 	{
 		import std.algorithm : countUntil;
@@ -47,7 +46,7 @@ struct SignalT(Slot)
 		}
 	}
 
-	@system
+
 	void emit(Parameters!Slot args)
 	{
 		foreach (ref slot; slots) {

--- a/source/vecs/signal.d
+++ b/source/vecs/signal.d
@@ -62,7 +62,7 @@ private:
 @("signal: empty")
 unittest
 {
-	Signal!() sig; // empty signal
+	SignalT!(void delegate()) sig;
 	size_t num;
 	auto fun = () { num++; };
 
@@ -79,8 +79,8 @@ unittest
 @("signal: different instances having the same Signal type")
 unittest
 {
-	Signal!(int) sigA;
-	Signal!(int) sigB;
+	SignalT!(void delegate(int)) sigA;
+	SignalT!(void delegate(int)) sigB;
 	size_t num;
 
 	sigA.connect((int x) { num = x; });
@@ -96,7 +96,7 @@ unittest
 unittest
 {
 	import std.functional : toDelegate;
-	Signal!(size_t*) sig;
+	SignalT!(void delegate(size_t*)) sig;
 	size_t num;
 
 	auto fun = function(size_t* n) { (*n)++; };

--- a/source/vecs/signal.d
+++ b/source/vecs/signal.d
@@ -54,6 +54,7 @@ struct SignalT(Slot)
 		foreach (slot; slots) slot(args);
 	}
 
+private:
 	Slot[] slots;
 }
 

--- a/source/vecs/signal.d
+++ b/source/vecs/signal.d
@@ -41,12 +41,11 @@ struct SignalT(Slot)
 
 	void disconnect(Slot slot)
 	{
-		import std.algorithm : countUntil;
-		auto index = slots.countUntil(slot);
+		import std.algorithm : countUntil, remove, SwapStrategy;
+		immutable index = slots.countUntil(slot);
+
 		if (index != -1)
-		{
-			slots = slots[0 .. index] ~ slots[index+1 .. $];
-		}
+			slots = slots.remove!(SwapStrategy.unstable)(index);
 	}
 
 

--- a/source/vecs/signal.d
+++ b/source/vecs/signal.d
@@ -51,9 +51,7 @@ struct SignalT(Slot)
 
 	void emit(Parameters!Slot args)
 	{
-		foreach (ref slot; slots) {
-			slot(args);
-		}
+		foreach (slot; slots) slot(args);
 	}
 
 	Slot[] slots;

--- a/source/vecs/signal.d
+++ b/source/vecs/signal.d
@@ -2,19 +2,20 @@ module vecs.signal;
 
 version(vecs_unittest) import aurorafw.unit.assertion;
 
-struct Signal(T ...)
-{
-	alias SlotType = void delegate(T);
-	alias SlotTypeRef = void delegate(ref T);
+import std.traits : isDelegate, Parameters;
 
+alias Signal(T...) = SignalT!(void delegate(T));
+struct SignalT(Slot)
+	if (isDelegate!Slot)
+{
 	@safe pure nothrow
-	void connect(SlotType slot)
+	void connect(Slot slot)
 	{
 		slots ~= slot;
 	}
 
 	@safe pure nothrow
-	void disconnect(SlotType slot)
+	void disconnect(Slot slot)
 	{
 		import std.algorithm : countUntil;
 		auto index = slots.countUntil(slot);
@@ -25,14 +26,14 @@ struct Signal(T ...)
 	}
 
 	@system
-	void emit(T args)
+	void emit(Parameters!Slot args)
 	{
 		foreach (ref slot; slots) {
 			slot(args);
 		}
 	}
 
-	SlotType[] slots;
+	Slot[] slots;
 }
 
 @system

--- a/source/vecs/signal.d
+++ b/source/vecs/signal.d
@@ -2,12 +2,27 @@ module vecs.signal;
 
 version(vecs_unittest) import aurorafw.unit.assertion;
 
-import std.traits : isDelegate, Parameters;
+import std.traits : isDelegate, Parameters, OriginalType;
+import std.traits : FunctionAttribute, SetFunctionAttributes;
 
 alias Signal(T...) = SignalT!(void delegate(T));
 struct SignalT(Slot)
 	if (isDelegate!Slot)
 {
+	template attributes(alias attrs)
+		if (is(typeof(attrs) : OriginalType!FunctionAttribute))
+	{
+		alias attributes = SignalT!(SetFunctionAttributes!(Slot, "D", attrs));
+	}
+
+
+	template attributes(alias slot)
+		if (is(slot : void delegate()))
+	{
+		alias attributes = SignalT!slot;
+	}
+
+
 	@safe pure nothrow
 	void connect(Slot slot)
 	{

--- a/source/vecs/signal.d
+++ b/source/vecs/signal.d
@@ -3,7 +3,7 @@ module vecs.signal;
 version(vecs_unittest) import aurorafw.unit.assertion;
 
 import std.traits : isDelegate, Parameters, OriginalType;
-import std.traits : FunctionAttribute, SetFunctionAttributes;
+import std.traits : FunctionAttribute, functionAttributes, SetFunctionAttributes;
 
 alias Signal(T...) = SignalT!(void delegate(T));
 struct SignalT(Slot)
@@ -20,6 +20,13 @@ struct SignalT(Slot)
 		if (is(slot : void delegate()))
 	{
 		alias attributes = SignalT!slot;
+	}
+
+
+	template parameters(alias slot)
+		if (is(slot : void delegate(Args), Args...))
+	{
+		alias parameters = SignalT!(SetFunctionAttributes!(slot, "D", functionAttributes!Slot));
 	}
 
 

--- a/source/vecs/signal.d
+++ b/source/vecs/signal.d
@@ -5,7 +5,8 @@ version(vecs_unittest) import aurorafw.unit.assertion;
 import std.traits : isDelegate, Parameters, OriginalType;
 import std.traits : FunctionAttribute, functionAttributes, SetFunctionAttributes;
 
-alias Signal(T...) = SignalT!(void delegate(T));
+alias Signal = SignalT!(void delegate());
+
 struct SignalT(Slot)
 	if (isDelegate!Slot)
 {

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -529,10 +529,10 @@ public:
 }
 
 @("[Storage] component manipulation")
-unittest
+@safe pure nothrow unittest
 {
 	struct Position { ulong x, y; }
-	scope storage = new Storage!Position;
+	scope storage = new Storage!(Position, void delegate() @safe pure nothrow);
 
 	with (storage) {
 		add(Entity(0));
@@ -568,9 +568,9 @@ unittest
 }
 
 @("[Storage] entity manipulation")
-unittest
+@safe pure nothrow unittest
 {
-	scope storage = new Storage!int;
+	scope storage = new Storage!(int, void delegate() @safe pure nothrow @nogc);
 
 	with (storage) {
 		add(Entity(0));
@@ -607,9 +607,9 @@ unittest
 }
 
 @("[Storage] getOrSet")
-unittest
+@safe pure nothrow unittest
 {
-	scope storage = new Storage!int();
+	scope storage = new Storage!(int, void delegate() @safe pure nothrow @nogc);
 
 	assert(*storage.getOrSet(Entity(0), 55) == 55);
 	assert(*storage.getOrSet(Entity(0), 13) == 55);
@@ -619,7 +619,7 @@ version(assert)
 @("[Storage] getOrSet (invalid entities)")
 unittest
 {
-	scope storage = new Storage!int();
+	scope storage = new Storage!int;
 
 	storage.add(Entity(0));
 
@@ -627,13 +627,13 @@ unittest
 }
 
 @("[Storage] signals")
-unittest
+@safe pure nothrow unittest
 {
-	scope storage = new Storage!int;
+	scope storage = new Storage!(int, void delegate() @safe pure nothrow @nogc);
 	enum e = Entity(0);
 
 	int value;
-	void delegate(Entity, int*) @safe fun = (Entity, int*) { value++; };
+	void delegate(Entity, int*) @safe pure nothrow @nogc fun = (Entity, int*) { value++; };
 
 	storage.onSet.connect(fun);
 	storage.onRemove.connect(fun);

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -635,7 +635,7 @@ unittest
 	enum e = Entity(0);
 
 	int value;
-	void delegate(Entity, int*) fun = (Entity, int*) { value++; };
+	void delegate(Entity, int*) @safe fun = (Entity, int*) { value++; };
 
 	storage.onSet.connect(fun);
 	storage.onRemove.connect(fun);

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -190,7 +190,7 @@ public:
 		(() @trusted pure nothrow @nogc => this.storage = cast(void*) storage)();
 		this.entities = &storage.entities;
 		this.contains = &storage.contains;
-		this.remove = &storage.remove;
+		this.remove = &storage.remove!();
 		this.clear = &storage.clear;
 		this.size = &storage.size;
 	}
@@ -203,7 +203,7 @@ public:
 	}
 
 	bool delegate(in Entity e) @safe pure nothrow @nogc const contains;
-	bool delegate(in Entity e) @system remove;
+	bool delegate(in Entity e) remove;
 	void delegate() @safe pure nothrow clear;
 	size_t delegate() @safe pure nothrow @nogc @property const size;
 
@@ -236,7 +236,7 @@ package:
 	auto storage = sinfo.get!(int, fun);
 
 	assert(&storage.contains is sinfo.contains);
-	assert(&storage.remove is sinfo.remove);
+	assert(&storage.remove!() is sinfo.remove);
 	assert(&storage.clear is sinfo.clear);
 	assert(&storage.size is sinfo.size);
 }
@@ -271,7 +271,7 @@ package class Storage(Component, Fun = void delegate() @safe)
 
 	Returns: A pointer to the component of the entity.
 	*/
-	Component* add(in Entity entity)
+	Component* add()(in Entity entity)
 	{
 		Component* component = _add(entity);
 		*component = Component.init;
@@ -312,8 +312,7 @@ package class Storage(Component, Fun = void delegate() @safe)
 
 	Returns: A pointer to the component of the entity.
 	*/
-	@system
-	Component* set(in Entity entity, Component component)
+	Component* set()(in Entity entity, Component component)
 	{
 		Component* comp = _add(entity);
 		*comp = component;
@@ -333,8 +332,7 @@ package class Storage(Component, Fun = void delegate() @safe)
 
 	Returns: True if the entity was removed, false otherwise.
 	*/
-	@system
-	bool remove(in Entity entity)
+	bool remove()(in Entity entity)
 	{
 		if (!contains(entity)) return false;
 
@@ -422,8 +420,7 @@ package class Storage(Component, Fun = void delegate() @safe)
 	 *
 	 * Returns: `Component*` pointing to the component associated.
 	 */
-	@system
-	Component* getOrSet(in Entity e, Component component)
+	Component* getOrSet()(in Entity e, Component component)
 		in (!(e.id < _sparsedEntities.length
 			&& _sparsedEntities[e.id] < _packedEntities.length
 			&& _packedEntities[_sparsedEntities[e.id]].id == e.id
@@ -498,6 +495,7 @@ private:
 
 	Retuns: A pointer to the component of the entity.
 	*/
+	@safe pure nothrow
 	Component* _add(in Entity entity)
 		in (!(entity.id < _sparsedEntities.length
 			&& _sparsedEntities[entity.id] < _packedEntities.length

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -184,7 +184,7 @@ package struct StorageInfo
 public:
 	this(Component, Fun = void delegate() @safe)()
 	{
-		auto storage = new Storage!Component();
+		auto storage = new Storage!(Component, Fun)();
 		this.cid = TypeInfoComponent!Component;
 
 		(() @trusted pure nothrow @nogc => this.storage = cast(void*) storage)();
@@ -196,10 +196,10 @@ public:
 	}
 
 	///
-	Storage!Component get(Component)()
+	Storage!(Component, Fun) get(Component, Fun)()
 		in (cid is TypeInfoComponent!Component)
 	{
-		return (() @trusted pure nothrow @nogc => cast(Storage!Component) storage)(); // safe cast
+		return (() @trusted pure nothrow @nogc => cast(Storage!(Component, Fun)) storage)(); // safe cast
 	}
 
 	bool delegate(in Entity e) @safe pure nothrow @nogc const contains;
@@ -227,12 +227,13 @@ package:
 @("[StorageInfo] instance manipulation")
 @safe pure nothrow unittest
 {
-	auto sinfo = StorageInfo().__ctor!int;
+	alias fun = void delegate();
+	auto sinfo = StorageInfo().__ctor!(int, fun);
 
 	assert(sinfo.cid is TypeInfoComponent!int);
-	assert(sinfo.get!int !is null);
+	assert(sinfo.get!(int, fun) !is null);
 
-	auto storage = sinfo.get!int;
+	auto storage = sinfo.get!(int, fun);
 
 	assert(&storage.contains is sinfo.contains);
 	assert(&storage.remove is sinfo.remove);
@@ -244,9 +245,10 @@ version(assert)
 @("[StorageInfo] instance manipulation (component getter missmatch)")
 unittest
 {
-	auto sinfo = StorageInfo().__ctor!int;
+	alias fun = void delegate();
+	auto sinfo = StorageInfo().__ctor!(int, fun);
 
-	assertThrown!AssertError(sinfo.get!size_t());
+	assertThrown!AssertError(sinfo.get!(size_t, fun)());
 }
 
 

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -256,7 +256,7 @@ unittest
  *
  * Params: Component = a valid component.
  */
-package class Storage(Component)
+package class Storage(Component, Fun = void delegate() @safe)
 	if (isComponent!Component)
 {
 	/**

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -526,8 +526,8 @@ private:
 	Component[] _components;
 
 public:
-	Signal!(Entity,Component*) onSet;
-	Signal!(Entity,Component*) onRemove;
+	SignalT!Fun.parameters!(void delegate(Entity, Component*)) onSet;
+	SignalT!Fun.parameters!(void delegate(Entity, Component*)) onRemove;
 }
 
 @("[Storage] component manipulation")

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -182,7 +182,7 @@ unittest
 package struct StorageInfo
 {
 public:
-	this(Component)()
+	this(Component, Fun = void delegate() @safe)()
 	{
 		auto storage = new Storage!Component();
 		this.cid = TypeInfoComponent!Component;


### PR DESCRIPTION
The dependency on `Signal` was restricting the usage of VECS to `@system` code. This PR fixes this issue and allows (not only Signal to be used with `@safe pure nothrow @nogc`) all VECS functions that were restricted to `@system` with `@safe pure nothrow`.

Unfortunately, this fix comes with some major changes to the usage of the lib. The solution was to allow the user to restrict himself to whatever minimum safety zone he wanted by passing the attributes to EntityManager. These same attributes are then used to generate the internal signal delegate slot types. Although I find this to be the best solution at the moment, this means that EntityManager has to be a template, which cascades to every type that depends on it.

The most affected type was the `Query`. To access the components, some queries have a `StorageInfo` array. Before, the way to gain access to `Storage` was to use the `get` function with the `Component` type. However, this change also causes `Storage` to hold a template argument for the attributes, meaning that the `Query` has to know which `attributes` the user used in order to cast to the same `Storage`.

The default attribute of EntityManager is `@safe`.
The default attribute of Signal is `none`.

Changes:
* rename EntityManager to EntityManagerImpl
* EntityManagerImpl is now a template
* EntityManager is now an alias to `EntityManagerImpl!(void delegate() @safe)
* StorageInfo receives the attributes in functions `ctor` and `get`
* Storage receives the attributes
* rename Signal to SignalImpl
* SignalImpl now receives a delegate
* Signal is an alias to `SignalImpl!(void delegate())`
* Signal function connect now works with function pointers
* Query now receives `EntityManagerImpl` as the first argument
* EntityBuilder is now a template and receives an `EntityManagerImpl`
* implement opEquals for EntityBuilder
* refactored `@system` labeled functions to templates in EntityManager and Storage
* add attributes to functions in Storage

Signal usage:
```d
alias SignalA = SignalImpl!(void delegate(int, ref uint) @safe pure) sig; // defines the slot type
// connect and emit stay the same

alias SignalB = Signal
	.attributes!(void delegate() @safe pure) // defines the attributes - must be an empty delegate
	.paramaters!(void delegate(int, ref uint)); // defined the parameters - attributes are NOT used

static assert(is(SignalA == SignalB)); // same type
```

EntityManager usage:
```d
auto worldA = new EntityManager(); // EntityManagerImpl!(void delegate() @safe);
auto worldB = new EntityManagerImpl!(void delegate() @safe pure nothrow @nogc);
```

Query drawback:
```d
alias World = EntityManagerImpl!(void delegate() @safe pure nothrow);

void systemA(Query!(World, Tuple!(int, uint)) query) { ... }

void main()
{
	auto world = new World();

	systemA(world.query!(int, uint)); // stays the same
}
```