### PR TITLE
fix Storage function patch return type

### DIFF
--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -1161,6 +1161,7 @@ private:
 	entity.patch!int((ref int i) { i = 45; });
 
 	assert(*integral == 45);
+	assert(world.patchComponent!(int, string)(entity, (ref int) {}, (ref string s) {}) == tuple(integral, str));
 
 	Position* position;
 	uint* uintegral;

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -358,12 +358,22 @@ public:
 	*/
 	template patchComponent(Components...)
 	{
-		void patchComponent(Callbacks...)(in Entity entity, Callbacks callbacks)
+		import std.meta : staticMap;
+		alias PointerOf(T) = T*;
+
+		auto patchComponent(Callbacks...)(in Entity entity, Callbacks callbacks)
 			if (Components.length == Callbacks.length)
 			in (validEntity(entity))
 		{
+			staticMap!(PointerOf, Components) C;
+
 			static foreach (i, Component; Components)
-				_assureStorage!Component.patch(entity, callbacks[i]);
+				C[i] = _assureStorage!Component.patch(entity, callbacks[i]);
+
+			static if (Components.length == 1)
+				return C[0];
+			else
+				return tuple(C);
 		}
 	}
 

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -355,6 +355,8 @@ public:
 		Components: Component types to patch.
 		entity: a valid entity.
 		callbacks: callbacks to call for each Component type.
+
+	Returns: A pointer or `Tuple` of pointers to the patched components.
 	*/
 	template patchComponent(Components...)
 	{

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -330,23 +330,25 @@ package class Storage(Component, Fun = void delegate() @safe)
 		entity: an entity in the storage.
 		fn: the callback to call.
 	*/
-	void patch(Fn : void delegate(ref Component))(in Entity entity, Fn fn)
+	Component* patch(Fn : void delegate(ref Component))(in Entity entity, Fn fn)
 		in (contains(entity))
 	{
-		fn(_components[_sparsedEntities[entity]]);
+		Component* component = &_components[_sparsedEntities[entity]];
+		fn(*component);
+		return component;
 	}
 
 
 	/// Ditto
-	void patch(Fn : void function(ref Component))(in Entity entity, Fn fn)
+	Component* patch(Fn : void function(ref Component))(in Entity entity, Fn fn)
 	{
 		import std.functional : toDelegate;
 
 		// workarround for toDelegate bug not working with @safe functions
 		static if (is(Fn : void function(ref Component) @safe))
-			patch(entity, (() @trusted => fn.toDelegate())());
+			return patch(entity, (() @trusted => fn.toDelegate())());
 		else
-			patch(entity, fn.toDelegate());
+			return patch(entity, fn.toDelegate());
 	}
 
 

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -329,6 +329,8 @@ package class Storage(Component, Fun = void delegate() @safe)
 	Params:
 		entity: an entity in the storage.
 		fn: the callback to call.
+
+	Returns: A pointer to the patched component.
 	*/
 	Component* patch(Fn : void delegate(ref Component))(in Entity entity, Fn fn)
 		in (contains(entity))


### PR DESCRIPTION
Changed:
* function patch in Storage returns a pointer to the patched component
* function patchComponent in EntityManager returns a pointer or a Tuple of pointers to the patched components

```d
auto world = new EntityManager();
auto entity = world.entity.add!(int, string);

assert(*world.patchComponent!int(entity, (ref int i) { i = 5; }) == 5);

int* i;
string* s;

AliasSeq!(i, s) = world.patchComponent!(int, string)(entity,
	(ref int i) { i = 10; },
	(ref string s) { s = "hi"; }
);

assert(*i == 10);
assert(*s == "hi");
```