### PR TITLE
Feature implement function replace

### DIFF
--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -97,7 +97,17 @@ public:
 		}
 	}
 
-	// TODO: documentation
+	/**
+	Replaces a component of an entity.
+
+	Attempting to use an invalid entity leads to undefined behavior.
+
+	Params:
+		Comonent: Component type to replace.
+		args: arguments to contruct the Component type.
+
+	Returns: This instance.
+	*/
 	EntityBuilder replace(Component, Args...)(auto ref Args args)
 	{
 		import core.lifetime : forward;

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -97,6 +97,15 @@ public:
 		}
 	}
 
+	// TODO: documentation
+	EntityBuilder replace(Component, Args...)(auto ref Args args)
+	{
+		import core.lifetime : forward;
+
+		entityManager.replaceComponent!Component(entity, forward!args);
+		return this;
+	}
+
 	/**
 	Removes components from an entity.
 

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -382,7 +382,25 @@ public:
 	}
 
 
-	// TODO: documentation
+	/**
+	Replaces a component of an entity.
+
+	Attempting to use an invalid entity leads to undefined behavior.
+
+	Examples:
+	---
+	auto world = new EntityManager();
+
+	assert(*world.replaceComponent!int(world.entity.add!int, 3) == 3);
+	---
+
+	Params:
+		Comonent: Component type to replace.
+		entity: a valid entity.
+		args: arguments to contruct the Component type.
+
+	Returns: A pointer to the replaced component.
+	*/
 	Component* replaceComponent(Component, Args...)(in Entity entity, auto ref Args args)
 		in (validEntity(entity))
 	{

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -382,6 +382,26 @@ public:
 	}
 
 
+	// TODO: documentation
+	// TODO: unit tests
+	Component* replaceComponent(Component, Args...)(in Entity entity, auto ref Args args)
+		in (validEntity(entity))
+	{
+		import core.lifetime : emplace, forward;
+
+		return _assureStorage!Component.patch(entity, (ref Component c) {
+			Component[Component.sizeof] buf = void;
+
+			// emplace can be @trusted if the struct ctor is @safe
+			// with multiple ctors we must verify the correspondent one to args
+			static if (is(Component == struct) && !__traits(compiles, () @safe => Component(forward!args)))
+				c = *emplace!Component(buf, forward!args);
+			else
+				c = *(() @trusted => emplace!Component(buf, forward!args))();
+		});
+	}
+
+
 	/**
 	Removes components from an entity.
 

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -383,7 +383,6 @@ public:
 
 
 	// TODO: documentation
-	// TODO: unit tests
 	Component* replaceComponent(Component, Args...)(in Entity entity, auto ref Args args)
 		in (validEntity(entity))
 	{
@@ -1185,6 +1184,8 @@ private:
 	assert(*integral == 45);
 	assert(world.patchComponent!(int, string)(entity, (ref int) {}, (ref string s) {}) == tuple(integral, str));
 
+	assert(*world.replaceComponent!int(entity, 3) == 3);
+
 	Position* position;
 	uint* uintegral;
 
@@ -1205,6 +1206,7 @@ unittest
 	const entity = world.entity;
 
 	assertThrown!AssertError(world.getComponent!int(entity));
+	assertThrown!AssertError(world.replaceComponent!int(entity, 0));
 	assertThrown!AssertError(world.patchComponent!int(entity, (ref int i) {}));
 
 	const invalid = Entity(entity.id, entity.batch + 1);
@@ -1212,6 +1214,7 @@ unittest
 	assertThrown!AssertError(world.addComponent!int(invalid));
 	assertThrown!AssertError(world.setComponent!int(invalid, 0));
 	assertThrown!AssertError(world.emplaceComponent!int(invalid, 0));
+	assertThrown!AssertError(world.replaceComponent!int(invalid, 0));
 	assertThrown!AssertError(world.patchComponent!int(invalid, (ref int i) {}));
 	assertThrown!AssertError(world.getComponent!int(invalid));
 	assertThrown!AssertError(world.getOrSet!int(invalid));


### PR DESCRIPTION
Depends on: #25

Changes:
* implement function replace in EntityBuilder
* implement function replaceComponent in EntityManager

```d
struct Foo
{
	this(int i) {}
	this(int a, int b) @safe {}
}

void main() @safe
{
	auto world = new EntityManager();

	// correctly checks safety with struct constructors
	auto entity = world.entity.add!Foo.replace!Foo(2, 3); // ok
	entity.replace!Foo(3); // ctor not @safe, won't compile
}
```
