### PR TITLE
Feature function reset

### DIFF
--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -136,6 +136,13 @@ public:
 		return this;
 	}
 
+	// TODO: documentation
+	EntityBuilder reset(Components...)()
+	{
+		entityManager.resetComponent!Components(entity);
+		return this;
+	}
+
 	/**
 	Removes components from an entity.
 

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -136,7 +136,17 @@ public:
 		return this;
 	}
 
-	// TODO: documentation
+	/**
+	Replaces a component of an entity with the init state of the Component type
+	if it owes it.
+
+	Attempting to use an invalid entity leads to undefined behavior.
+
+	Params:
+		Comonents: Component types to replace.
+
+	Returns: This instance.
+	*/
 	EntityBuilder reset(Components...)()
 	{
 		entityManager.resetComponent!Components(entity);

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -460,6 +460,31 @@ public:
 	}
 
 
+	// TODO: documentation
+	// TODO: unit tests
+	auto resetComponent(Components...)(in Entity entity)
+		if (Components.length)
+		in (validEntity(entity))
+	{
+		import std.meta : staticMap;
+		alias PointerOf(T) = T*;
+		staticMap!(PointerOf, Components) C;
+
+		static foreach (i, Component; Components)
+			C[i] = _assureStorage!Component.patch(entity, (ref Component c) {
+				import core.lifetime : emplace;
+				Component[Component.sizeof] buf = void;
+
+				c = *(() @trusted => emplace!Component(buf, Component.init))();
+			});
+
+		static if (Components.length == 1)
+			return C[0];
+		else
+			return tuple(C);
+	}
+
+
 	/**
 	Removes components from an entity.
 

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -461,7 +461,6 @@ public:
 
 
 	// TODO: documentation
-	// TODO: unit tests
 	auto resetComponent(Components...)(in Entity entity)
 		if (Components.length)
 		in (validEntity(entity))
@@ -1269,6 +1268,7 @@ private:
 	assert(world.patchComponent!(int, string)(entity, (ref int) {}, (ref string s) {}) == tuple(integral, str));
 
 	assert(*world.replaceComponent!int(entity, 3) == 3);
+	assert(*world.resetComponent!int(entity) == int.init);
 
 	Position* position;
 	uint* uintegral;
@@ -1290,12 +1290,14 @@ unittest
 	const entity = world.entity;
 
 	assertThrown!AssertError(world.getComponent!int(entity));
+	assertThrown!AssertError(world.resetComponent!int(entity));
 	assertThrown!AssertError(world.replaceComponent!int(entity, 0));
 	assertThrown!AssertError(world.patchComponent!int(entity, (ref int i) {}));
 
 	const invalid = Entity(entity.id, entity.batch + 1);
 
 	assertThrown!AssertError(world.addComponent!int(invalid));
+	assertThrown!AssertError(world.resetComponent!int(invalid));
 	assertThrown!AssertError(world.setComponent!int(invalid, 0));
 	assertThrown!AssertError(world.emplaceComponent!int(invalid, 0));
 	assertThrown!AssertError(world.replaceComponent!int(invalid, 0));

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -460,7 +460,25 @@ public:
 	}
 
 
-	// TODO: documentation
+	/**
+	Replaces a component of an entity with the init state of the Component type
+	if it owes it.
+
+	Attempting to use an invalid entity leads to undefined behavior.
+
+	Examples:
+	---
+	auto world = new EntityManager();
+
+	assert(*world.resetComponent!int(world.entity.emplace!int(4)) == int.init);
+	---
+
+	Params:
+		Comonents: Component types to replace.
+		entity: a valid entity.
+
+	Returns: A pointer or `Tuple` of pointers to the replaced component.
+	*/
 	auto resetComponent(Components...)(in Entity entity)
 		if (Components.length)
 		in (validEntity(entity))


### PR DESCRIPTION
Replaces a component by another constructed to its init state.

Changes:
* implement reset in EntityBuilder
* implement resetComponent in EntityManagerT

```d
auto world = new EntityManager();

assert(*world.resetComponent!int(world.entity.emplace!int(5)) == int.init)
```