### PR TITLE
Feature function addOrReset

### DIFF
--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -151,6 +151,13 @@ public:
 		return this;
 	}
 
+	// TODO: documentation
+	EntityBuilder addOrReset(Components...)()
+	{
+		entityManager.addOrResetComponent!Components(entity);
+		return this;
+	}
+
 	/**
 	Removes components from an entity.
 

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -151,7 +151,17 @@ public:
 		return this;
 	}
 
-	// TODO: documentation
+	/**
+	Adds or replaces a component of an entity with the init state of the
+	Component type if it owes it.
+
+	Attempting to use an invalid entity leads to undefined behavior.
+
+	Params:
+		Comonents: Component types to add or replace.
+
+	Returns: This instance.
+	*/
 	EntityBuilder addOrReset(Components...)()
 	{
 		entityManager.addOrResetComponent!Components(entity);

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -503,7 +503,6 @@ public:
 
 
 	// TODO: documentation
-	// TODO: unit tests
 	auto addOrResetComponent(Components...)(in Entity entity)
 		if (Components.length)
 		in (validEntity(entity))
@@ -1292,7 +1291,7 @@ private:
 
 	struct Position { ulong x, y; }
 	auto entity = world.entity
-		.add!int
+		.addOrReset!int
 		.set("Hello")
 		.emplaceOrReplace!Position(1LU, 4LU);
 
@@ -1346,6 +1345,7 @@ unittest
 
 	assertThrown!AssertError(world.addComponent!int(invalid));
 	assertThrown!AssertError(world.resetComponent!int(invalid));
+	assertThrown!AssertError(world.addOrResetComponent!int(invalid));
 	assertThrown!AssertError(world.setComponent!int(invalid, 0));
 	assertThrown!AssertError(world.emplaceComponent!int(invalid, 0));
 	assertThrown!AssertError(world.replaceComponent!int(invalid, 0));

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -502,7 +502,25 @@ public:
 	}
 
 
-	// TODO: documentation
+	/**
+	Adds or replaces a component of an entity with the init state of the
+	Component type if it owes it.
+
+	Attempting to use an invalid entity leads to undefined behavior.
+
+	Examples:
+	---
+	auto world = new EntityManager();
+
+	assert(*world.addOrResetComponent!int(world.entity.addOrReset!int) == int.init);
+	---
+
+	Params:
+		Comonents: Component types to add or replace.
+		entity: a valid entity.
+
+	Returns: A pointer or `Tuple` of pointers to the added or replaced components.
+	*/
 	auto addOrResetComponent(Components...)(in Entity entity)
 		if (Components.length)
 		in (validEntity(entity))


### PR DESCRIPTION
Adds or replaces a component type owned by an entity, constructing the new one with its init state

Changes:
* implemented addOrReset in EntityBuilder
* implemented addOrResetComponent in EntityManagerT

```d
auto world = new EntityManager();

world.entity
	.addOrReset!int  // add
	.addOrReset!int; // replace
```