### PR TITLE
Refactor function emplace to handle multiple component types

### DIFF
--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -51,10 +51,13 @@ public:
 
 	Returns: This instance.
 	*/
-	EntityBuilder emplace(Component, Args...)(auto ref Args args)
+	template emplace(Components...)
 	{
-		entityManager.emplaceComponent!Component(entity, args);
-		return this;
+		EntityBuilder emplace(Args...)(auto ref Args args)
+		{
+			entityManager.emplaceComponent!Components(entity, args);
+			return this;
+		}
 	}
 
 	/**

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -109,12 +109,15 @@ public:
 
 	Returns: This instance.
 	*/
-	EntityBuilder replace(Component, Args...)(auto ref Args args)
+	template replace(Components...)
 	{
-		import core.lifetime : forward;
+		EntityBuilder replace(Args...)(auto ref Args args)
+		{
+			import core.lifetime : forward;
 
-		entityManager.replaceComponent!Component(entity, forward!args);
-		return this;
+			entityManager.replaceComponent!Components(entity, forward!args);
+			return this;
+		}
 	}
 
 	/**

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -99,13 +99,13 @@ public:
 	}
 
 	/**
-	Replaces a component of an entity.
+	Replaces components of an entity.
 
 	Attempting to use an invalid entity leads to undefined behavior.
 
 	Params:
-		Comonent: Component type to replace.
-		args: arguments to contruct the Component type.
+		Components: Component types to replace.
+		args: arguments to contruct the Component types.
 
 	Returns: This instance.
 	*/

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -38,16 +38,16 @@ public:
 	}
 
 	/**
-	Assigns the `Component` to the `entity`. The `Component` is initialized with
-	the `args` provided.
+	Assigns the Components to an entity. The Components are initialized with
+	the args provided.
 
 	Attempting to use an invalid entity leads to undefined behavior.
 
 	Signal: emits `onSet` after each component is assigned.
 
 	Params:
-		Component = Component type to emplace.
-		args = arguments to contruct the Component type.
+		Components = Component types to emplace.
+		args = arguments to contruct the Component types.
 
 	Returns: This instance.
 	*/

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -121,14 +121,14 @@ public:
 	}
 
 	/**
-	Replaces or emplaces a component of an entity if it owes or not the same
-	Component type.
+	Replaces or emplaces components of an entity if it owes or not the same
+	Component types.
 
 	Attempting to use an invalid entity leads to undefined behavior.
 
 	Params:
-		Comonent: Component type to emplace or replace.
-		args: arguments to contruct the Component type.
+		Components: Component types to emplace or replace.
+		args: arguments to contruct the Component types.
 
 	Returns: This instance.
 	*/

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -132,12 +132,15 @@ public:
 
 	Returns: This instance.
 	*/
-	EntityBuilder emplaceOrReplace(Component, Args...)(auto ref Args args)
+	template emplaceOrReplace(Components...)
 	{
-		import core.lifetime : forward;
+		EntityBuilder emplaceOrReplace(Args...)(auto ref Args args)
+		{
+			import core.lifetime : forward;
 
-		entityManager.emplaceOrReplaceComponent!Component(entity, forward!args);
-		return this;
+			entityManager.emplaceOrReplaceComponent!Components(entity, forward!args);
+			return this;
+		}
 	}
 
 	/**

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -86,8 +86,8 @@ public:
 
 
 	/**
-	Assigns the `Component` to the `entity`. The `Component` is initialized with
-	the `args` provided.
+	Assigns Components to an entity. The Components is initialized with
+	the args provided.
 
 	Attempting to use an invalid entity leads to undefined behavior.
 
@@ -96,17 +96,26 @@ public:
 	struct Position { ulong x, y; }
 	auto world = new EntityManager();
 
-	Position* i = world.emplace!Position(world.entity, 2LU, 3LU);
+	// with one component field arguments can be used
+	Position* i = world.emplaceComponent!Position(world.entity, 2LU, 3LU);
+
+	int* i; Position* pos;
+
+	// with multiple components only the type can be used, not field arguments
+	// components can be infered as well
+	AliasSeq!(i, pos) = world.emplaceComponent!(int, Position)(world.entity, 3, Position(1, 2));
+
+	assert(*i = 3 && *pos = Position(1, 2));
 	---
 
 	Signal: emits `onSet` after each component is assigned.
 
 	Params:
-		Component = Component type to emplace.
+		Components = Component types to emplace.
 		entity = a valid entity.
-		args = arguments to contruct the Component type.
+		args = arguments to contruct the Component types.
 
-	Returns: A pointer to the emplaced component.
+	Returns: A pointer or `Tuple` of pointers to the emplaced components.
 	*/
 	template emplaceComponent(Components...)
 		if (Components.length)

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -433,21 +433,45 @@ public:
 
 	Returns: A pointer to the replaced component.
 	*/
-	Component* replaceComponent(Component, Args...)(in Entity entity, auto ref Args args)
-		in (validEntity(entity))
+	template replaceComponent(Components...)
+		if (Components.length)
 	{
 		import core.lifetime : emplace, forward;
 
-		return _assureStorage!Component.patch(entity, (ref Component c) {
-			Component[Component.sizeof] buf = void;
+		static if (Components.length == 1)
+		{
+			alias Component = Components[0];
+			Component* replaceComponent(Args...)(in Entity entity, auto ref Args args)
+				in (validEntity(entity))
+			{
+				return _assureStorage!Component.patch(entity, (ref Component c) {
+					Component[Component.sizeof] buf = void;
 
-			// emplace can be @trusted if the struct ctor is @safe
-			// with multiple ctors we must verify the correspondent one to args
-			static if (is(Component == struct) && !__traits(compiles, () @safe => Component(forward!args)))
-				c = *emplace!Component(buf, forward!args);
-			else
-				c = *(() @trusted => emplace!Component(buf, forward!args))();
-		});
+					// emplace can be @trusted if the struct ctor is @safe
+					// with multiple ctors we must verify the correspondent one to args
+					static if (is(Component == struct) && !__traits(compiles, () @safe => Component(forward!args)))
+						c = *emplace!Component(buf, forward!args);
+					else
+						c = *(() @trusted => emplace!Component(buf, forward!args))();
+				});
+			}
+		}
+		else
+		{
+			import std.meta : staticMap;
+			alias PointerOf(T) = T*;
+
+			auto replaceComponent(in Entity entity, auto ref Components args)
+				in (validEntity(entity))
+			{
+				staticMap!(PointerOf, Components) C;
+
+				static foreach (i, Component; Components)
+					C[i] = replaceComponent!Component(entity, forward!(args[i]));
+
+				return tuple(C);
+			}
+		}
 	}
 
 

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -415,7 +415,7 @@ public:
 
 
 	/**
-	Replaces a component of an entity.
+	Replaces components of an entity.
 
 	Attempting to use an invalid entity leads to undefined behavior.
 
@@ -424,14 +424,24 @@ public:
 	auto world = new EntityManager();
 
 	assert(*world.replaceComponent!int(world.entity.add!int, 3) == 3);
+
+
+	struct Position { ulong x, y; }
+	int* i; Position* pos;
+
+	// with multiple components only the type can be used, not field arguments
+	// components can be infered as well
+	AliasSeq!(i, pos) = world.emplaceComponent!(int, Position)(world.entity.add!(int, Position), 3, Position(1, 2));
+
+	assert(*i = 3 && *pos = Position(1, 2));
 	---
 
 	Params:
-		Comonent: Component type to replace.
+		Components: Component types to replace.
 		entity: a valid entity.
-		args: arguments to contruct the Component type.
+		args: arguments to contruct the Component types.
 
-	Returns: A pointer to the replaced component.
+	Returns: A pointer or `Tuple` of pointers to the replaced components.
 	*/
 	template replaceComponent(Components...)
 		if (Components.length)

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -452,8 +452,8 @@ public:
 
 
 	/**
-	Replaces or emplaces a component of an entity if it owes or not the same
-	Component type.
+	Replaces or emplaces components of an entity if it owes or not the same
+	Component types.
 
 	Attempting to use an invalid entity leads to undefined behavior.
 
@@ -462,14 +462,23 @@ public:
 	auto world = new EntityManager();
 
 	assert(*world.entity.emplaceOrReplace!int(3) == 3);
+
+	struct Position { ulong x, y; }
+	int* i; Position* pos;
+
+	// with multiple components only the type can be used, not field arguments
+	// components can be infered as well
+	AliasSeq!(i, pos) = world.emplaceComponent!(int, Position)(world.entity, 3, Position(1, 2));
+
+	assert(*i = 3 && *pos = Position(1, 2));
 	---
 
 	Params:
-		Comonent: Component type to emplace or replace.
+		Comonents: Component types to emplace or replace.
 		entity: a valid entity.
-		args: arguments to contruct the Component type.
+		args: arguments to contruct the Component types.
 
-	Returns: A pointer to the emplaced or replaced component.
+	Returns: A pointer os `Tuple` of pointers to the emplaced or replaced components.
 	*/
 	template emplaceOrReplaceComponent(Components...)
 		if (Components.length)


### PR DESCRIPTION
Emplace will merge with set logic in the future, so this is the first step towards that.

Changes:
* refactored `emplace, replace and emplaceOrReplace` to handle multiple Component types

Note: No unit tests were added in this PR as they will be replacing `set` unit tests when it is removed.