### PR TITLE
Fix patch lambdas logic

### DIFF
--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -458,12 +458,7 @@ public:
 					ubyte[Component.sizeof] tmp = void;
 					auto buf = (() @trusted => cast(Component*)(tmp.ptr))();
 
-					// emplace can be @trusted if the struct ctor is @safe
-					// with multiple ctors we must verify the correspondent one to args
-					static if (is(Component == struct) && !__traits(compiles, () @safe => Component(forward!args)))
-						c = *emplace!Component(buf, forward!args);
-					else
-						c = *(() @trusted => emplace!Component(buf, forward!args))();
+					c = *emplace!Component(buf, forward!args);
 				});
 			}
 		}
@@ -533,12 +528,7 @@ public:
 							ubyte[Component.sizeof] tmp = void;
 							auto buf = (() @trusted => cast(Component*)(tmp.ptr))();
 
-							// emplace can be @trusted if the struct ctor is @safe
-							// with multiple ctors we must verify the correspondent one to args
-							static if (is(Component == struct) && !__traits(compiles, () @safe => Component(forward!args)))
-								c = *emplace!Component(buf, forward!args);
-							else
-								c = *(() @trusted => emplace!Component(buf, forward!args))();
+							c = *emplace!Component(buf, forward!args);
 						})
 					: storage.emplace(entity, forward!args);
 			}

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -455,7 +455,8 @@ public:
 				in (validEntity(entity))
 			{
 				return _assureStorage!Component.patch(entity, (ref Component c) {
-					Component[Component.sizeof] buf = void;
+					ubyte[Component.sizeof] tmp = void;
+					auto buf = (() @trusted => cast(Component*)(tmp.ptr))();
 
 					// emplace can be @trusted if the struct ctor is @safe
 					// with multiple ctors we must verify the correspondent one to args
@@ -529,7 +530,8 @@ public:
 
 				return storage.contains(entity)
 					? storage.patch(entity, (ref Component c) {
-							Component[Component.sizeof] buf = void;
+							ubyte[Component.sizeof] tmp = void;
+							auto buf = (() @trusted => cast(Component*)(tmp.ptr))();
 
 							// emplace can be @trusted if the struct ctor is @safe
 							// with multiple ctors we must verify the correspondent one to args
@@ -590,7 +592,8 @@ public:
 		static foreach (i, Component; Components)
 			C[i] = _assureStorage!Component.patch(entity, (ref Component c) {
 				import core.lifetime : emplace;
-				Component[Component.sizeof] buf = void;
+				ubyte[Component.sizeof] tmp = void;
+				auto buf = (() @trusted => cast(Component*)(tmp.ptr))();
 
 				c = *(() @trusted => emplace!Component(buf, Component.init))();
 			});
@@ -635,7 +638,8 @@ public:
 			C[i] = storage.contains(entity)
 				? storage.patch(entity, (ref Component c) {
 					import core.lifetime : emplace;
-					Component[Component.sizeof] buf = void;
+					ubyte[Component.sizeof] tmp = void;
+					auto buf = (() @trusted => cast(Component*)(tmp.ptr))();
 
 					c = *(() @trusted => emplace!Component(buf, Component.init))();
 				})

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -581,11 +581,7 @@ public:
 
 		static foreach (i, Component; Components)
 			C[i] = _assureStorage!Component.patch(entity, (ref Component c) {
-				import core.lifetime : emplace;
-				ubyte[Component.sizeof] tmp = void;
-				auto buf = (() @trusted => cast(Component*)(tmp.ptr))();
-
-				c = *(() @trusted => emplace!Component(buf, Component.init))();
+				c = Component.init;
 			});
 
 		static if (Components.length == 1)
@@ -626,13 +622,7 @@ public:
 		{
 			auto storage = _assureStorage!Component;
 			C[i] = storage.contains(entity)
-				? storage.patch(entity, (ref Component c) {
-					import core.lifetime : emplace;
-					ubyte[Component.sizeof] tmp = void;
-					auto buf = (() @trusted => cast(Component*)(tmp.ptr))();
-
-					c = *(() @trusted => emplace!Component(buf, Component.init))();
-				})
+				? storage.patch(entity, (ref Component c) { c = Component.init; })
 				: storage.add(entity);
 		}
 


### PR DESCRIPTION
Changes:
* buffers were being initialized with more memory than needed
* the void initialization would not work for pointers when passing to emplace
* removed unneeded safety check for struct constructors
* removed unneeded emplace call when copying with the init state
