### PR TITLE
Fix EntityBuilder emplace based functions to infer component types

### DIFF
--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -123,12 +123,25 @@ public:
 	*/
 	template replace(Components...)
 	{
-		EntityBuilder replace(Args...)(auto ref Args args)
+		static if (Components.length == 1)
 		{
-			import core.lifetime : forward;
+			EntityBuilder replace(Args...)(auto ref Args args)
+			{
+				import core.lifetime : forward;
 
-			entityManager.replaceComponent!Components(entity, forward!args);
-			return this;
+				entityManager.replaceComponent!Components(entity, forward!args);
+				return this;
+			}
+		}
+		else
+		{
+			EntityBuilder replace(auto ref Components args)
+			{
+				import core.lifetime : forward;
+
+				entityManager.replaceComponent!Components(entity, forward!args);
+				return this;
+			}
 		}
 	}
 

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -159,12 +159,25 @@ public:
 	*/
 	template emplaceOrReplace(Components...)
 	{
-		EntityBuilder emplaceOrReplace(Args...)(auto ref Args args)
+		static if (Components.length == 1)
 		{
-			import core.lifetime : forward;
+			EntityBuilder emplaceOrReplace(Args...)(auto ref Args args)
+			{
+				import core.lifetime : forward;
 
-			entityManager.emplaceOrReplaceComponent!Components(entity, forward!args);
-			return this;
+				entityManager.emplaceOrReplaceComponent!Components(entity, forward!args);
+				return this;
+			}
+		}
+		else
+		{
+			EntityBuilder emplaceOrReplace(auto ref Components args)
+			{
+				import core.lifetime : forward;
+
+				entityManager.emplaceOrReplaceComponent!Components(entity, forward!args);
+				return this;
+			}
 		}
 	}
 

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -52,11 +52,23 @@ public:
 	Returns: This instance.
 	*/
 	template emplace(Components...)
+		if (Components.length)
 	{
-		EntityBuilder emplace(Args...)(auto ref Args args)
+		static if (Components.length == 1)
 		{
-			entityManager.emplaceComponent!Components(entity, args);
-			return this;
+			EntityBuilder emplace(Args...)(auto ref Args args)
+			{
+				entityManager.emplaceComponent!Components(entity, args);
+				return this;
+			}
+		}
+		else
+		{
+			EntityBuilder emplace(auto ref Components args)
+			{
+				entityManager.emplaceComponent!Components(entity, args);
+				return this;
+			}
 		}
 	}
 


### PR DESCRIPTION
The functions `emplace, replace and emplaceOrReplace` were not behaving the same way the corresponding ones in EntityManagerT. With more than one component type, the types can be inferred.