### PR TITLE
Refactor function getOrEmplaceComponent to follow emplace based functions format

### DIFF
--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -729,7 +729,6 @@ public:
 
 
 	// TODO: documentation
-	// TODO: unit tests
 	Component* getOrEmplaceComponent(Component, Args...)(in Entity entity, auto ref Args args)
 		in (validEntity(entity))
 	{
@@ -1361,8 +1360,11 @@ private:
 	assert(*position == Position(1, 4));
 	assert(!uintegral);
 
-	assert(*world.getOrEmplaceComponent!uint(entity, 45) == 45);
-	assert(*world.getOrEmplaceComponent!uint(entity, 64) == 45);
+	int* i; ulong* ul;
+	AliasSeq!(i, ul) = world.getOrEmplaceComponent!(int, ulong)(entity, 24, 45);
+
+	assert(*i == 0); // entity had an int
+	assert(*ul == 45); // entity didn't have an ulong
 }
 
 version(assert)

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -728,7 +728,35 @@ public:
 	}
 
 
-	// TODO: documentation
+	/**
+	Gets the type if owned by an entity otherwise emplaces a new one.
+
+	Attempting to use an invalid entity leads to undefined behavior.
+
+	Examples:
+	---
+	auto world = new EntityManager();
+
+	auto entity = world.entity;
+	assert(*world.getOrEmplaceComponent!int(entity, 3) == 3);
+
+	struct Position { ulong x, y; }
+	int* i; Position* pos;
+	AliasSeq!(i, pos) = world.getOrEmplaceComponent!(int, Position)(entity, 27, Position(1, 2));
+
+	assert(*i == 3); // entity owed an int type
+	assert(*pos == Position(1, 2)); // entity didn't owe a Position type
+	---
+
+	Params:
+		Components = Component types to get.
+		entity = a valid entity.
+		args = arguments to contruct the Component types if the entity does not
+			owe them.
+
+	Returns: A pointer or a `Tuple` of pointers to the components previously
+	owed or emplaced.
+	*/
 	Component* getOrEmplaceComponent(Component, Args...)(in Entity entity, auto ref Args args)
 		in (validEntity(entity))
 	{

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -741,6 +741,23 @@ public:
 			: storage.emplace(entity, forward!args);
 	}
 
+	/// Ditto
+	auto getOrEmplaceComponent(Components...)(in Entity entity, auto ref Components args)
+		if (Components.length > 1)
+		in (validEntity(entity))
+	{
+		import core.lifetime : forward;
+		import std.meta : staticMap;
+
+		alias PointerOf(T) = T*;
+		staticMap!(PointerOf, Components) C;
+
+		static foreach (i, Component; Components)
+			C[i] = getOrEmplaceComponent!Component(entity, forward!(args[i]));
+
+		return tuple(C);
+	}
+
 
 	/**
 	 * Get the size of Component Storage. The size represents how many entities

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -728,40 +728,17 @@ public:
 	}
 
 
-	/**
-	 * Fetch the component associated to an entity. If the entity is already
-	 *     associated with a component of that type then the same is immediatly
-	 *     returned, otherwise the component is set and returned. Passing an
-	 *     invalid entity leads to undefined behaviour.
-	 *
-	 * Safety: The **internal code** is @safe, however, because of **Signal**
-	 *     dependency, the method must be @system.
-	 *
-	 * Signal: Emits onSet **after** the component is set **if** set.
-	 *
-	 * Params:
-	 *     e = entity to fetch the associated component.
-	 *     component = component to set if there is none associated.
-	 *
-	 * Examples:
-	 * ---
-	 * struct Foo { int i; }
-	 * auto em = new EntityManager();
-	 * auto e = em.gen();
-	 *
-	 * // asociates Foo.init with e returning a pointer to it
-	 * assert(Foo.init == *em.getOrEmplaceComponent!Foo(e));
-	 *
-	 * // returns a pointer to the already associated Foo
-	 * assert(Foo.init == *em.getOrEmplaceComponent(e, Foo(5)));
-	 * ---
-	 *
-	 * Returns: `Component*` pointing to the component associated.
-	 */
-	Component* getOrEmplaceComponent(Component)(in Entity e, Component component = Component.init)
-		in (validEntity(e))
+	// TODO: documentation
+	// TODO: unit tests
+	Component* getOrEmplaceComponent(Component, Args...)(in Entity entity, auto ref Args args)
+		in (validEntity(entity))
 	{
-		return _assureStorage!Component().getOrEmplace(e, component);
+		import core.lifetime : forward;
+
+		auto storage = _assureStorage!Component;
+		return storage.contains(entity)
+			? storage.get(entity)
+			: storage.emplace(entity, forward!args);
 	}
 
 

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -420,32 +420,6 @@ package class Storage(Component, Fun = void delegate() @safe)
 
 
 	/**
-	 * Fetch the component if associated to the entity, otherwise the component
-	 *     passed set then returned. Emits onSet if the component is set.
-	 *
-	 * Safety: The **internal code** is @safe, however, beacause of **Signal**
-	 *     dependency, the method must be @system.
-	 *
-	 * Signal: Emits onSet **after** the component is set **if** set.
-	 *
-	 * Params:
-	 *     e = entity to search.
-	 *     component = component to set if there is none associated.
-	 *
-	 * Returns: `Component*` pointing to the component associated.
-	 */
-	Component* getOrEmplace()(in Entity e, Component component)
-		in (!(e.id < _sparsedEntities.length
-			&& _sparsedEntities[e.id] < _packedEntities.length
-			&& _packedEntities[_sparsedEntities[e.id]].id == e.id
-			&&_packedEntities[_sparsedEntities[e.id]].batch != e.batch)
-		)
-	{
-		return contains(e) ? get(e) : emplace(e, component);
-	}
-
-
-	/**
 	 * Gets the amount of components/entities stored.
 	 *
 	 * Returns: `size_t` with the amount of components/entities.
@@ -621,26 +595,6 @@ unittest
 	storage.add(Entity(1));
 
 	assertThrown!AssertError(storage.add(Entity(1, 4)));
-}
-
-@("[Storage] getOrEmplace")
-@safe pure nothrow unittest
-{
-	scope storage = new Storage!(int, void delegate() @safe pure nothrow @nogc);
-
-	assert(*storage.getOrEmplace(Entity(0), 55) == 55);
-	assert(*storage.getOrEmplace(Entity(0), 13) == 55);
-}
-
-version(assert)
-@("[Storage] getOrEmplace (invalid entities)")
-unittest
-{
-	scope storage = new Storage!int;
-
-	storage.add(Entity(0));
-
-	assertThrown!AssertError(storage.getOrEmplace(Entity(0, 1), 6));
 }
 
 @("[Storage] signals")


### PR DESCRIPTION
The function `getOrEmplace` should have the same features all `emplace` based functions have.

Changes:
* removed `getOrEmplace` from Storage
* added function `getOrEmplaceComponent` support for multiple arguments in EntityManagerT with 1 component
* added function `getOrEmplaceComponent` support for multiple components in EntityManagerT

```d
auto world = new EntityManager();

auto entity = world.entity.emplace!int(5);

struct Position { ulong x, y; }
int* i; Position* pos;
AliasSeq!(i, pos) = world.getOrEmplace!(int, Position)(entity, 23, Position(3, 4));

assert(*i == 5);
assert(*pos == Positon(3, 4));
```