### PR TITLE
Feature function getOrAddComponent

### DIFF
--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -787,7 +787,6 @@ public:
 
 
 	// TODO: documentation
-	// TODO: unit tests
 	auto getOrAddComponent(Components...)(in Entity entity)
 		if (Components.length)
 		in (validEntity(entity))
@@ -1419,6 +1418,8 @@ private:
 
 	assert(*i == 0); // entity had an int
 	assert(*ul == 45); // entity didn't have an ulong
+
+	assert(*world.getOrAddComponent!int(world.entity) == int.init);
 }
 
 version(assert)
@@ -1443,6 +1444,7 @@ unittest
 	assertThrown!AssertError(world.emplaceOrReplaceComponent!int(invalid, 0));
 	assertThrown!AssertError(world.patchComponent!int(invalid, (ref int i) {}));
 	assertThrown!AssertError(world.getComponent!int(invalid));
+	assertThrown!AssertError(world.getOrAddComponent!int(invalid));
 	assertThrown!AssertError(world.getOrEmplaceComponent!int(invalid));
 	assertThrown!AssertError(world.removeComponent!int(invalid));
 	assertThrown!AssertError(world.removeAllComponents(invalid));

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -786,7 +786,33 @@ public:
 	}
 
 
-	// TODO: documentation
+	/**
+	Gets the type if owned by an entity otherwise emplaces a new one constructed
+	to its init state.
+
+	Attempting to use an invalid entity leads to undefined behavior.
+
+	Examples:
+	---
+	auto world = new EntityManager();
+
+	auto entity = world.entity.emplace!int(3);
+
+	struct Position { ulong x, y; }
+	int* i; Position* pos;
+	AliasSeq!(i, pos) = world.getOrAdd!(int, Position)(entity);
+
+	assert(*i == 3); // entity owed an int type
+	assert(*pos == Position.init); // entity didn't owe a Position type
+	---
+
+	Params:
+		Components = Component types to get.
+		entity = a valid entity.
+
+	Returns: A pointer or a `Tuple` of pointers to the components previously
+	owed or emplaced.
+	*/
 	auto getOrAddComponent(Components...)(in Entity entity)
 		if (Components.length)
 		in (validEntity(entity))

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -786,6 +786,32 @@ public:
 	}
 
 
+	// TODO: documentation
+	// TODO: unit tests
+	auto getOrAddComponent(Components...)(in Entity entity)
+		if (Components.length)
+		in (validEntity(entity))
+	{
+		import std.meta : staticMap;
+
+		alias PointerOf(T) = T*;
+		staticMap!(PointerOf, Components) C;
+
+		static foreach (i, Component; Components)
+		{
+			auto storage = _assureStorage!Component;
+			C[i] = storage.contains(entity)
+				? storage.get(entity)
+				: storage.add(entity);
+		}
+
+		static if (Components.length == 1)
+			return C[0];
+		else
+			return tuple(C);
+	}
+
+
 	/**
 	 * Get the size of Component Storage. The size represents how many entities
 	 *     and components are stored in the Component's storage.


### PR DESCRIPTION
The function `getOrAddComponent` works the same way as `getOrEmplaceComponent` but it constructs the component to its init state.

```d
auto world = new EntityManager();

assert(*world.getOrAddComponent!int(world.entity) == 0);
```