### PR TITLE
Refactor Storage signal onSet

### DIFF
--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -60,7 +60,7 @@ public:
 	Tuple!(int*, string*) t = world.add!(int, string)(world.entity);
 	---
 
-	Signal: emits `onSet` after each component is assigned.
+	Signal: emits `onConstruct` after each component is assigned.
 
 	Params:
 		Components = Component types to add.
@@ -108,7 +108,7 @@ public:
 	assert(*i = 3 && *pos = Position(1, 2));
 	---
 
-	Signal: emits `onSet` after each component is assigned.
+	Signal: emits `onConstruct` after each component is assigned.
 
 	Params:
 		Components = Component types to emplace.
@@ -246,7 +246,7 @@ public:
 
 
 	/**
-	 * This signal occurs every time a Component is set. The onSet signal is
+	 * This signal occurs every time a Component is set. The onConstruct signal is
 	 *     emitted **after** the Component is set. A Component is set when
 	 *     assigning a new one to an entity or when updating an existing one.
 	 *
@@ -263,15 +263,15 @@ public:
 	 * auto fun = (Entity,Foo*) { i++; };
 	 *
 	 * // bind a callback
-	 * em.onSet!Foo().connect(fun);
+	 * em.onConstruct!Foo().connect(fun);
 	 *
-	 * // this emits onSet
+	 * // this emits onConstruct
 	 * em.gen!Foo();
 	 *
 	 * assert(1 == i);
 	 *
 	 * // unbind a callback
-	 * em.onSet!Foo().disconnect(fun);
+	 * em.onConstruct!Foo().disconnect(fun);
 	 *
 	 * em.gen!Foo();
 	 * assert(1 == i);
@@ -279,7 +279,7 @@ public:
 	 *
 	 * Returns: `Signal!(Entity,Component*)`
 	 */
-	ref auto onSet(Component)()
+	ref auto onConstruct(Component)()
 	{
 		return _assureStorage!Component.onConstruct;
 	}
@@ -301,7 +301,7 @@ public:
 	 * auto fun = (Entity,Foo*) { i++; };
 	 *
 	 * // bind a callback
-	 * em.onSet!Foo().connect(fun);
+	 * em.onConstruct!Foo().connect(fun);
 	 *
 	 * // this emits onRemove
 	 * em.destroyEntity(em.gen!Foo());
@@ -309,7 +309,7 @@ public:
 	 * assert(1 == i);
 	 *
 	 * // unbind a callback
-	 * em.onSet!Foo().disconnect(fun);
+	 * em.onConstruct!Foo().disconnect(fun);
 	 *
 	 * em.destroyEntity(em.gen!Foo());
 	 * assert(1 == i);

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -279,7 +279,7 @@ public:
 	 *
 	 * Returns: `Signal!(Entity,Component*)`
 	 */
-	ref auto onConstruct(Component)()
+	ref onConstruct(Component)()
 	{
 		return _assureStorage!Component.onConstruct;
 	}

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -281,7 +281,7 @@ public:
 	 */
 	ref auto onSet(Component)()
 	{
-		return _assureStorage!Component.onSet;
+		return _assureStorage!Component.onConstruct;
 	}
 
 

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -246,39 +246,25 @@ public:
 
 
 	/**
-	 * This signal occurs every time a Component is set. The onConstruct signal is
-	 *     emitted **after** the Component is set. A Component is set when
-	 *     assigning a new one to an entity or when updating an existing one.
-	 *
-	 * Params:
-	 *     Component = a valid component type
-	 *
-	 * Examples:
-	 * ---
-	 * struct Foo {}
-	 * auto em = new EntityManager();
-	 * int i;
-	 *
-	 * // callback **MUST be a delegate** and return **void**
-	 * auto fun = (Entity,Foo*) { i++; };
-	 *
-	 * // bind a callback
-	 * em.onConstruct!Foo().connect(fun);
-	 *
-	 * // this emits onConstruct
-	 * em.gen!Foo();
-	 *
-	 * assert(1 == i);
-	 *
-	 * // unbind a callback
-	 * em.onConstruct!Foo().disconnect(fun);
-	 *
-	 * em.gen!Foo();
-	 * assert(1 == i);
-	 * ---
-	 *
-	 * Returns: `Signal!(Entity,Component*)`
-	 */
+	Signal emited when a component is contructed.
+
+	Examples:
+	---
+	auto world = new EntityManager();
+
+	int result;
+	world.onConstruct!int.connect((in Entity, ref int i) { result = i; });
+
+	world.entity.emplace!int(5);
+
+	assert(result == 5);
+	---
+
+	Params:
+		Component = Signal's Component type.
+
+	Returns: A reference to the Signal.
+	*/
 	ref onConstruct(Component)()
 	{
 		return _assureStorage!Component.onConstruct;

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -275,7 +275,7 @@ package class Storage(Component, Fun = void delegate() @safe)
 	{
 		Component* component = _add(entity);
 		*component = Component.init;
-		onConstruct.emit(entity, component);
+		onConstruct.emit(entity, *component);
 		return component;
 	}
 
@@ -297,7 +297,7 @@ package class Storage(Component, Fun = void delegate() @safe)
 
 		Component* component = _add(entity);
 		component.emplace(forward!args);
-		onConstruct.emit(entity, component);
+		onConstruct.emit(entity, *component);
 		return component;
 	}
 
@@ -512,7 +512,7 @@ private:
 	Component[] _components;
 
 public:
-	SignalT!Fun.parameters!(void delegate(Entity, Component*)) onConstruct;
+	SignalT!Fun.parameters!(void delegate(Entity, ref Component)) onConstruct;
 	SignalT!Fun.parameters!(void delegate(Entity, Component*)) onRemove;
 }
 
@@ -604,10 +604,10 @@ unittest
 	enum e = Entity(0);
 
 	int value;
-	void delegate(Entity, int*) @safe pure nothrow @nogc fun = (Entity, int*) { value++; };
+	void delegate(Entity, ref int) @safe pure nothrow @nogc fun = (Entity, ref int) { value++; };
 
 	storage.onConstruct.connect(fun);
-	storage.onRemove.connect(fun);
+	storage.onRemove.connect((Entity, int*) { value++; });
 
 	storage.add(e);
 	assert(value == 1);

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -264,7 +264,7 @@ package class Storage(Component, Fun = void delegate() @safe)
 	/**
 	Adds or updates the component for the entity.
 
-	Signal: emits $(LREF onSet) after adding the component.
+	Signal: emits $(LREF onConstruct) after adding the component.
 
 	Params:
 		entity = a valid entity.
@@ -275,7 +275,7 @@ package class Storage(Component, Fun = void delegate() @safe)
 	{
 		Component* component = _add(entity);
 		*component = Component.init;
-		onSet.emit(entity, component);
+		onConstruct.emit(entity, component);
 		return component;
 	}
 
@@ -283,7 +283,7 @@ package class Storage(Component, Fun = void delegate() @safe)
 	/**
 	Emplace or replace the component for the entity.
 
-	Signal: emits $(LREF onSet) after adding the component.
+	Signal: emits $(LREF onConstruct) after adding the component.
 
 	Params:
 		entity = a valid entity.
@@ -297,7 +297,7 @@ package class Storage(Component, Fun = void delegate() @safe)
 
 		Component* component = _add(entity);
 		component.emplace(forward!args);
-		onSet.emit(entity, component);
+		onConstruct.emit(entity, component);
 		return component;
 	}
 
@@ -512,7 +512,7 @@ private:
 	Component[] _components;
 
 public:
-	SignalT!Fun.parameters!(void delegate(Entity, Component*)) onSet;
+	SignalT!Fun.parameters!(void delegate(Entity, Component*)) onConstruct;
 	SignalT!Fun.parameters!(void delegate(Entity, Component*)) onRemove;
 }
 
@@ -606,7 +606,7 @@ unittest
 	int value;
 	void delegate(Entity, int*) @safe pure nothrow @nogc fun = (Entity, int*) { value++; };
 
-	storage.onSet.connect(fun);
+	storage.onConstruct.connect(fun);
 	storage.onRemove.connect(fun);
 
 	storage.add(e);


### PR DESCRIPTION
The signal `onSet` is not really accurate anymore with the latest changes. This PR renames it to something more suiting and refactors its arguments to a safer code call.

Changes:
* renamed `onSet` to `onConstruct` in `Storage` and `EntityManager`
* refactored `onConstruct` arguments to emit a ref Component instead of a pointer

```d
auto world = new EntityManager();

world.onContruct!int.connect((in Entity, ref int) {});
```