### PR TITLE
Refactor signal onRemove

### DIFF
--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -306,7 +306,7 @@ public:
 	 *
 	 * Returns: `Signal!(Entity,Component*)`
 	 */
-	ref auto onRemove(Component)()
+	ref onRemove(Component)()
 	{
 		return _assureStorage!Component.onRemove;
 	}

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -272,40 +272,20 @@ public:
 
 
 	/**
-	 * This signal occurs every time a Component is disassociated from an
-	 *     entity. The onRemove signal is emitted **before** the Component is
-	 *     removed. A Component is removed when removing a one from an entity or
-	 *     when discarding an entity.
-	 *
-	 * Examples:
-	 * ---
-	 * struct Foo {}
-	 * auto em = new EntityManager();
-	 * int i;
-	 *
-	 * // callback **MUST be a delegate** and return **void**
-	 * auto fun = (Entity,Foo*) { i++; };
-	 *
-	 * // bind a callback
-	 * em.onConstruct!Foo().connect(fun);
-	 *
-	 * // this emits onRemove
-	 * em.destroyEntity(em.gen!Foo());
-	 *
-	 * assert(1 == i);
-	 *
-	 * // unbind a callback
-	 * em.onConstruct!Foo().disconnect(fun);
-	 *
-	 * em.destroyEntity(em.gen!Foo());
-	 * assert(1 == i);
-	 * ---
-	 *
-	 * Params:
-	 *     Component = a valid component type
-	 *
-	 * Returns: `Signal!(Entity,Component*)`
-	 */
+	Signal emited before a component is removed.
+
+	Examples:
+	---
+	auto world = new EntityManager();
+
+	int result;
+	world.onRemove!int.connect((in Entity, ref int i) { result = i; });
+
+	world.removeComponent!int(world.entity.emplace!int(5));
+
+	assert(result == 5);
+	---
+	*/
 	ref onRemove(Component)()
 	{
 		return _assureStorage!Component.onRemove;

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -354,7 +354,7 @@ package class Storage(Component, Fun = void delegate() @safe)
 		import std.range : back, popBack;
 
 		// emit onRemove
-		onRemove.emit(entity, &_components[_sparsedEntities[entity.id]]);
+		onRemove.emit(entity, _components[_sparsedEntities[entity.id]]);
 
 		immutable last = _packedEntities.back;
 
@@ -513,7 +513,7 @@ private:
 
 public:
 	SignalT!Fun.parameters!(void delegate(Entity, ref Component)) onConstruct;
-	SignalT!Fun.parameters!(void delegate(Entity, Component*)) onRemove;
+	SignalT!Fun.parameters!(void delegate(Entity, ref Component)) onRemove;
 }
 
 @("[Storage] component manipulation")
@@ -607,7 +607,7 @@ unittest
 	void delegate(Entity, ref int) @safe pure nothrow @nogc fun = (Entity, ref int) { value++; };
 
 	storage.onConstruct.connect(fun);
-	storage.onRemove.connect((Entity, int*) { value++; });
+	storage.onRemove.connect(fun);
 
 	storage.add(e);
 	assert(value == 1);


### PR DESCRIPTION
Changes:
* function `onRemove` always returns ref in EntityManager
* refactored arguments to emit a ref instead of a pointer.

```d
auto world = new EntityManager();

int result;
world.onRemove!int.connect((in Entity, ref int i) { result = i; });

world.removeComponent!int(world.entity.emplace!int(5));

assert(result == 5);
```
