### PR TITLE
Feature signal onUpdate

### DIFF
--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -271,6 +271,28 @@ public:
 	}
 
 
+	/**
+	Signal emited when a component is contructed.
+
+	Examples:
+	---
+	auto world = new EntityManager();
+
+	int result;
+	world.onUpdate!int.connect((in Entity, ref int i) { result = i; });
+
+	world.entity
+		.add!int
+		.replace!int(5);
+
+	assert(result == 5);
+	---
+
+	Params:
+		Component = Signal's Component type.
+
+	Returns: A reference to the Signal.
+	*/
 	ref onUpdate(Component)()
 	{
 		return _assureStorage!Component.onUpdate;

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -306,6 +306,8 @@ public:
 	entity.patch!Position((ref Position pos) { pos.x = 24; });
 	---
 
+	Signal: emits $(LREF onUpdate) after the patch.
+
 	Params:
 		Components: Component types to patch.
 		entity: a valid entity.
@@ -356,6 +358,8 @@ public:
 
 	assert(*i = 3 && *pos = Position(1, 2));
 	---
+
+	Signal: emits $(LREF onUpdate) after the replacement.
 
 	Params:
 		Components: Component types to replace.
@@ -417,6 +421,8 @@ public:
 	assert(*i = 3 && *pos = Position(1, 2));
 	---
 
+	Signal: emits $(LREF onUpdate) if replaced.
+
 	Params:
 		Comonents: Component types to emplace or replace.
 		entity: a valid entity.
@@ -472,6 +478,8 @@ public:
 	assert(*world.resetComponent!int(world.entity.emplace!int(4)) == int.init);
 	---
 
+	Signal: emits $(LREF onUpdate) after the reset.
+
 	Params:
 		Comonents: Component types to replace.
 		entity: a valid entity.
@@ -510,6 +518,8 @@ public:
 
 	assert(*world.addOrResetComponent!int(world.entity.addOrReset!int) == int.init);
 	---
+
+	Signal: emits $(LREF onUpdate) if reset.
 
 	Params:
 		Comonents: Component types to add or replace.

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -271,6 +271,12 @@ public:
 	}
 
 
+	ref onUpdate(Component)()
+	{
+		return _assureStorage!Component.onUpdate;
+	}
+
+
 	/**
 	Signal emited before a component is removed.
 

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -611,11 +611,15 @@ unittest
 	void delegate(Entity, ref int) @safe pure nothrow @nogc fun = (Entity, ref int) { value++; };
 
 	storage.onConstruct.connect(fun);
+	storage.onUpdate.connect(fun);
 	storage.onRemove.connect(fun);
 
 	storage.add(e);
 	assert(value == 1);
 
-	storage.remove(e);
+	storage.patch(e, (ref int) {});
 	assert(value == 2);
+
+	storage.remove(e);
+	assert(value == 3);
 }

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -318,6 +318,7 @@ package class Storage(Component, Fun = void delegate() @safe)
 	{
 		Component* component = &_components[_sparsedEntities[entity]];
 		fn(*component);
+		onUpdate.emit(entity, *component);
 		return component;
 	}
 

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -307,6 +307,8 @@ package class Storage(Component, Fun = void delegate() @safe)
 
 	Attempting to use an invalid entity leads to undefined behavior.
 
+	Signal: emits $(LREF onUpdate) after the patch.
+
 	Params:
 		entity: an entity in the storage.
 		fn: the callback to call.

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -513,6 +513,7 @@ private:
 
 public:
 	SignalT!Fun.parameters!(void delegate(Entity, ref Component)) onConstruct;
+	SignalT!Fun.parameters!(void delegate(Entity, ref Component)) onUpdate;
 	SignalT!Fun.parameters!(void delegate(Entity, ref Component)) onRemove;
 }
 


### PR DESCRIPTION
The signal `onUpdate` is emitted after a component is updated. Functions that update components are the ones where an entity owes the Component type: `replace, patch, emplaceOrReplace, addOrReset`

Changes:
* added onUpdate Signal in Storage
* implemented onUpdate function in EntityManagerT
* refactored patch in Storage to emit onUpdate

```d
auto world = new EntityManager();

int result;
world.onUpdate!int.connect((in Entity, ref int i) { result = i; });

world.entity
	.add!int
	.replace!int(5);

assert(result == 5);
```