### PR TITLE
Feature Entity null comparison

### DIFF
--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -177,6 +177,12 @@ struct NullEntity
 		return true;
 	}
 
+	@safe pure nothrow @nogc
+	bool opEquals(typeof(null)) const
+	{
+		return true;
+	}
+
 	Entity opBinary(string op)(in size_t signature) const
 		if (op == "|")
 	{

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -146,7 +146,9 @@ public:
 	}
 
 	assert(Entity(Entity.maxid) == nullentity);
+	assert(Entity(Entity.maxid) == null);
 	assert(Entity(Entity.maxid, 45) == nullentity);
+	assert(Entity(Entity.maxid, 45) == null);
 }
 
 version(assert)

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -196,6 +196,7 @@ struct NullEntity
 {
 	assert(is(NullEntity : Entity));
 	assert(nullentity == nullentity);
+	assert(nullentity == null);
 	assert(nullentity == Entity.maxid);
 	assert((nullentity | Entity(4, 3)).batch == 3);
 }

--- a/source/vecs/entity.d
+++ b/source/vecs/entity.d
@@ -79,6 +79,13 @@ public:
 	}
 
 
+	@safe pure nothrow @nogc
+	bool opEquals(typeof(null)) const
+	{
+		return nullentity.opEquals(this);
+	}
+
+
 	@safe pure nothrow @nogc @property
 	size_t id() const
 	{


### PR DESCRIPTION
A `nullentity` if compared with `null` is true. This can make for a shorter syntax when comparing entities while keeping the readability ok. The main usage will be for internal implementations so this feature does not influence user code more than `nullentity` does. A `nullentity` can be seen as being equivalent to `null` without being `null` itself.

```d
assert(entitynull == null);
assert(Entity(Entity.maxid) == null);
```