### PR TITLE
Fix Storage function add not assigning correctly

### DIFF
--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -273,8 +273,10 @@ package class Storage(Component, Fun = void delegate() @safe)
 	*/
 	Component* add()(in Entity entity)
 	{
+		import core.lifetime : emplace;
+
 		Component* component = _add(entity);
-		*component = Component.init;
+		emplace(component);
 		onConstruct.emit(entity, *component);
 		return component;
 	}


### PR DESCRIPTION
The function `add` was making a copy instead of assuming the entry as uninitialized.