### PR TITLE
Refactor Storage sparse storage strategy 

### DIFF
--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -496,17 +496,14 @@ private:
 			&& _packedEntities[_sparsedEntities[entity.id]].batch != entity.batch
 		))
 	{
-		if (!contains(entity))
-		{
-			_packedEntities ~= entity; // set entity
-			_components.length++;
+		_packedEntities ~= entity; // set entity
+		_components.length++;
 
-			// map to the correct entity from the packedEntities from sparsedEntities
-			if (entity.id >= _sparsedEntities.length)
-				_sparsedEntities.length = entity.id + 1;
+		// map to the correct entity from the packedEntities from sparsedEntities
+		if (entity.id >= _sparsedEntities.length)
+			_sparsedEntities.length = entity.id + 1;
 
-			_sparsedEntities[entity.id] = _packedEntities.length - 1;
-		}
+		_sparsedEntities[entity.id] = _packedEntities.length - 1;
 
 		return &_components[_sparsedEntities[entity.id]];
 	}

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -489,11 +489,7 @@ private:
 	*/
 	@safe pure nothrow
 	Component* _add(in Entity entity)
-		in (!(entity.id < _sparsedEntities.length
-			&& _sparsedEntities[entity.id] < _packedEntities.length
-			&& _packedEntities[_sparsedEntities[entity.id]].id == entity.id
-			&& _packedEntities[_sparsedEntities[entity.id]].batch != entity.batch
-		))
+		in (!contains(entity))
 	{
 		// map to the correct entity from the packedEntities from sparsedEntities
 		if (entity.id >= _sparsedEntities.length)
@@ -545,11 +541,6 @@ public:
 
 	assert( storage.tryGet(Entity(0)));
 	assert(!storage.tryGet(Entity(1234)));
-
-	with (storage) {
-		assert(*add(Entity(5)) == *storage.get(Entity(5)));
-		assert(*emplace(Entity(3), 4, 6) == *storage.get(Entity(3)));
-	}
 
 	assert( storage.remove(Entity(3)));
 	assert(!storage.tryGet(Entity(3)));
@@ -607,6 +598,7 @@ unittest
 	storage.add(Entity(1));
 
 	assertThrown!AssertError(storage.add(Entity(1, 4)));
+	assertThrown!AssertError(storage.emplace(Entity(1, 4), 0));
 }
 
 @("[Storage] signals")

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -448,9 +448,7 @@ package class Storage(Component, Fun = void delegate() @safe)
 	@safe pure nothrow @nogc
 	bool contains(in Entity e) const
 	{
-		return e.id < _sparsedEntities.length
-			&& _sparsedEntities[e.id] < _packedEntities.length
-			&& _packedEntities[_sparsedEntities[e.id]] == e;
+		return e.id < _sparsedEntities.length && _sparsedEntities[e.id] != nullentity;
 	}
 
 
@@ -595,8 +593,9 @@ public:
 
 	assert(!storage.contains(Entity(0)));
 
-	assert(!storage.remove(Entity(5, 1)));
-	assert( storage.contains(Entity(5)));
+	// ignores batches, however they are tested by EntityManagerT
+	assert( storage.remove(Entity(5, 1)));
+	assert(!storage.contains(Entity(5)));
 }
 
 version(assert)

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -496,14 +496,23 @@ private:
 			&& _packedEntities[_sparsedEntities[entity.id]].batch != entity.batch
 		))
 	{
-		_packedEntities ~= entity; // set entity
-		_components.length++;
-
 		// map to the correct entity from the packedEntities from sparsedEntities
 		if (entity.id >= _sparsedEntities.length)
-			_sparsedEntities.length = entity.id + 1;
+		{
+			import std.algorithm : uninitializedFill;
 
-		_sparsedEntities[entity.id] = _packedEntities.length - 1;
+			immutable size = entity.id + 1;
+
+			_sparsedEntities.reserve(size);
+			auto slice = (() @trusted => _sparsedEntities.ptr[_sparsedEntities.length .. size])();
+			slice.uninitializedFill(nullentity);
+			_sparsedEntities ~= slice;
+		}
+
+		_sparsedEntities[entity.id] = _packedEntities.length;
+
+		_packedEntities ~= entity; // set entity
+		_components.length++;
 
 		return &_components[_sparsedEntities[entity.id]];
 	}

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -368,7 +368,8 @@ package class Storage(Component, Fun = void delegate() @safe)
 		swap(_packedEntities.back, _packedEntities[_sparsedEntities[entity.id]]);
 
 		// map the sparseEntities to the new value in packedEntities
-		swap(_sparsedEntities[last.id], _sparsedEntities[entity.id]);
+		_sparsedEntities[last.id] = _sparsedEntities[entity.id];
+		_sparsedEntities[entity.id] = nullentity;
 
 		// remove the last element
 		_components.popBack;


### PR DESCRIPTION
This PR optimizes some calls when removing or adding entities to a Storage.

Changes:
* when adding a new entity the not yet taken positions before the new position are initialized to nullentity instead of the init state
* when removing an entity a nullentity is assigned to its space
* refactored function contains to use only the sparse array
* refactored _add constraint to use the function contains