### PR TITLE
Remove Aurora framework assertion calls

### DIFF
--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -3,8 +3,6 @@ module vecs.entitybuilder;
 import vecs.entity;
 import vecs.entitymanager;
 
-version(vecs_unittest) import aurorafw.unit.assertion;
-
 
 /**
  * Helper struct to perform multiple action sequences.

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -15,7 +15,6 @@ import std.typecons : Tuple, tuple;
 
 version(vecs_unittest)
 {
-	import aurorafw.unit.assertion;
 	import std.exception : assertThrown;
 	import core.exception : AssertError;
 }

--- a/source/vecs/resource.d
+++ b/source/vecs/resource.d
@@ -1,10 +1,6 @@
 module vecs.resource;
 
-version(vecs_unittest)
-{
-	import aurorafw.unit.assertion;
-	import vecs.entitymanager;
-}
+version(vecs_unittest) import vecs.entitymanager;
 
 
 ///
@@ -87,21 +83,23 @@ unittest
 	auto em = new EntityManager();
 
 	em.addResource!State;
-	assertEquals("", em.resource!State.name);
+
+	import std.string : empty;
+	assert(em.resource!State.name.empty);
 
 	em.addResource!CState;
-	assertNull(em.resource!CState);
+	assert(!em.resource!CState);
 
 	// replace old CState resource
 	em.addResource(new CState(2f, 5f));
-	assertEquals(new CState(2f, 5f), em.resource!CState);
+	assert(em.resource!CState == new CState(2f, 5f));
 
 	em.addResource(EState.b);
-	assertEquals(EState.b, em.resource!EState);
+	assert(em.resource!EState == EState.b);
 
-	assertFalse(__traits(compiles, em.addResource!(int)()));
-	assertFalse(__traits(compiles, em.addResource!(int[])()));
-	assertFalse(__traits(compiles, em.addResource!(State*)()));
+	assert(!__traits(compiles, em.addResource!(int)()));
+	assert(!__traits(compiles, em.addResource!(int[])()));
+	assert(!__traits(compiles, em.addResource!(State*)()));
 }
 
 
@@ -124,5 +122,5 @@ unittest
 
 	threads.each!"a.join()";
 
-	assertFalse(ids[0] == ids[1]);
+	assert(ids[0] != ids[1]);
 }

--- a/source/vecs/signal.d
+++ b/source/vecs/signal.d
@@ -1,7 +1,5 @@
 module vecs.signal;
 
-version(vecs_unittest) import aurorafw.unit.assertion;
-
 import std.functional : toDelegate;
 import std.traits : isDelegate, Parameters, OriginalType;
 import std.traits : FunctionAttribute, functionAttributes, SetFunctionAttributes;

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -9,7 +9,6 @@ import std.typecons : Tuple;
 
 version(vecs_unittest)
 {
-	import aurorafw.unit.assertion;
 	import std.exception : assertThrown;
 	import core.exception : AssertError;
 }


### PR DESCRIPTION
All unit tests will not have any external dependency calls. The aurora framework will still be a dependency for now because of how it outputs the completed unit tests.