### PR TITLE
Fix: Patch functions should receive compile-time functions

### DIFF
--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -10,10 +10,11 @@ Patch a component of an entity.
 Attempting to use an invalid entity leads to undefined behavior.
 
 Params:
-	Components: Component types to patch.
-	callbacks: callbacks to call for each Component type.
+	Component: Component type to patch.
+	entityBuilder: the EntityBuilder that holds the Entity and EntityManagerT.
+	callbacks: callbacks to call.
 
-Returns: This instance.
+Returns: The entityBuilder used.
 */
 template patch(Component, callbacks...)
 {

--- a/source/vecs/entitybuilder.d
+++ b/source/vecs/entitybuilder.d
@@ -5,6 +5,26 @@ import vecs.entitymanager;
 
 
 /**
+Patch a component of an entity.
+
+Attempting to use an invalid entity leads to undefined behavior.
+
+Params:
+	Components: Component types to patch.
+	callbacks: callbacks to call for each Component type.
+
+Returns: This instance.
+*/
+template patch(Component, callbacks...)
+{
+	ref EntityBuilder patch(EntityBuilder)(return ref EntityBuilder entityBuilder)
+	{
+		with(entityBuilder) entityManager.patchComponent!(Component, callbacks)(entity);
+		return entityBuilder;
+	}
+}
+
+/**
  * Helper struct to perform multiple action sequences.
  */
 struct EntityBuilder(EntityManagerT)
@@ -65,26 +85,6 @@ public:
 
 		entityManager.emplaceComponent!Components(entity, forward!args);
 		return this;
-	}
-
-	/**
-	Patch a component of an entity.
-
-	Attempting to use an invalid entity leads to undefined behavior.
-
-	Params:
-		Components: Component types to patch.
-		callbacks: callbacks to call for each Component type.
-
-	Returns: This instance.
-	*/
-	template patch(Components...)
-	{
-		EntityBuilder patch(Callbacks...)(Callbacks callbacks)
-		{
-			entityManager.patchComponent!Components(entity, callbacks);
-			return this;
-		}
 	}
 
 	/**

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -22,6 +22,7 @@ version(vecs_unittest)
 }
 
 
+// Workaround for: https://issues.dlang.org/show_bug.cgi?id=5710
 /**
 Patch a component of an entity.
 
@@ -33,17 +34,18 @@ struct Position { ulong x, y; }
 auto world = new EntityManager();
 
 auto entity = world.entity.add!Position;
-entity.patch!Position((ref Position pos) { pos.x = 24; });
+world.patchComponent!(Position, (ref position) { pos.x = 24; })(entity);
 ---
 
 Signal: emits $(LREF onUpdate) after the patch.
 
 Params:
-	Components: Component types to patch.
+	Component: Component type to patch.
 	entity: a valid entity.
-	callbacks: callbacks to call for each Component type.
+	entityManager: the EntityManagerT that holds the entity.
+	callbacks: callbacks to call.
 
-Returns: A pointer or `Tuple` of pointers to the patched components.
+Returns: A pointer the patched component.
 */
 template patchComponent(Component, callbacks...)
 	if (callbacks.length)

--- a/source/vecs/entitymanager.d
+++ b/source/vecs/entitymanager.d
@@ -344,12 +344,7 @@ public:
 		if (Callbacks.length)
 		in (validEntity(entity))
 	{
-		Component* component;
-
-		static foreach (i, callback; callbacks)
-			component = _assureStorage!Component.patch(entity, callbacks[i]);
-
-		return component;
+		return _assureStorage!Component.patch(entity, callbacks);
 	}
 
 

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -23,7 +23,8 @@ Signal: emits $(LREF onUpdate) after the patch.
 
 Params:
 	entity: an entity in the storage.
-	fn: the callback to call.
+	storage: the Storage that holds the component.
+	callbacks: callbacks to call.
 
 Returns: A pointer to the patched component.
 */

--- a/source/vecs/storage.d
+++ b/source/vecs/storage.d
@@ -87,15 +87,16 @@ package class Storage(Component, Fun = void delegate() @safe)
 
 	Returns: A pointer to the patched component.
 	*/
-	Component* patch(Callback)(in Entity entity, Callback callback)
+	Component* patch(Callbacks...)(in Entity entity, Callbacks callbacks)
 		in (contains(entity))
 	{
+		import std.meta : All = allSatisfy;
 		import std.traits : Parameters, ReturnType;
 		enum isCallback(Fun) = is(ReturnType!Fun function(Parameters!Fun) : void function(ref Component));
-		static assert(isCallback!Callback);
+		static assert(All!(isCallback, Callbacks));
 
 		Component* component = &_components[_sparsedEntities[entity]];
-		callback(*component);
+		static foreach (callback; callbacks) callback(*component);
 		onUpdate.emit(entity, *component);
 		return component;
 	}


### PR DESCRIPTION
Depends on #68

Every callback that can be used in VECS is through template arguments. Patch functions are the only exception at the moment. The trade-off here is reducing the number of Components allowed in a patch in favor of more callbacks for a Component. This also brings consistency to VECS, every function that requires a callback will be through templates arguments. The advantages are: functions are checked in compile-time (the program won't fail at run-time), and the user can provide lambda functions without having to explicitly set the types (if lambda can be executed, the type are inferred automatically). 

With this change, lambdas are allowed to return any type other than void. The return value will be discarded. Some prefer having the `=>` syntax instead of having to create a scope.

```d
auto world = new EntityManager();

world.entity
	.add!int
	.patch!(int,
		(ref i) => i++,
		(const i) => world.entity.emplace!int(i + 2);
);
```